### PR TITLE
prefer single quote

### DIFF
--- a/lib/src/components/arm/arm.dart
+++ b/lib/src/components/arm/arm.dart
@@ -4,7 +4,7 @@ import 'package:viam_sdk/src/resource/base.dart';
 import 'package:viam_sdk/src/robot/client.dart';
 
 abstract class Arm extends Resource {
-  static const Subtype subtype = Subtype(ResourceNamespaceRDK, ResourceTypeComponent, "arm");
+  static const Subtype subtype = Subtype(ResourceNamespaceRDK, ResourceTypeComponent, 'arm');
 
   @override
   String name;

--- a/lib/src/components/base/base.dart
+++ b/lib/src/components/base/base.dart
@@ -4,7 +4,7 @@ import 'package:viam_sdk/src/resource/base.dart';
 import '../../robot/client.dart';
 
 abstract class Base extends Resource {
-  static const Subtype subtype = Subtype(ResourceNamespaceRDK, ResourceTypeComponent, "base");
+  static const Subtype subtype = Subtype(ResourceNamespaceRDK, ResourceTypeComponent, 'base');
 
   @override
   String name;

--- a/lib/src/components/movement_sensor/movement_sensor.dart
+++ b/lib/src/components/movement_sensor/movement_sensor.dart
@@ -15,7 +15,7 @@ class Position {
 typedef Properties = GetPropertiesResponse;
 
 abstract class MovementSensor extends Sensor {
-  static const Subtype subtype = Subtype(ResourceNamespaceRDK, ResourceTypeComponent, "movement_sensor");
+  static const Subtype subtype = Subtype(ResourceNamespaceRDK, ResourceTypeComponent, 'movement_sensor');
 
   MovementSensor(super.name);
 
@@ -48,44 +48,44 @@ abstract class MovementSensor extends Sensor {
     Map<String, dynamic> readings = {};
     try {
       Position pos = await getPosition(extra: extra);
-      readings["position"] = pos.coordinates;
-      readings["altitude"] = pos.altitude;
+      readings['position'] = pos.coordinates;
+      readings['altitude'] = pos.altitude;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow
-       print('Error: $exception');
+      print('Error: $exception');
     }
 
     try {
       Vector3 lv = await getLinearVelocity(extra: extra);
-      readings["linear_velocity"] = lv;
+      readings['linear_velocity'] = lv;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow
     }
 
     try {
       Vector3 av = await getAngularVelocity(extra: extra);
-      readings["angular_velocity"] = av;
+      readings['angular_velocity'] = av;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow
     }
 
     try {
       Vector3 la = await getLinearAcceleration(extra: extra);
-      readings["linear_acceleration"] = la;
+      readings['linear_acceleration'] = la;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow
     }
 
     try {
       double comp = await getCompassHeading(extra: extra);
-      readings["compass"] = comp;
+      readings['compass'] = comp;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow
     }
 
     try {
       Orientation orient = await getOrientation(extra: extra);
-      readings["orientation"] = orient;
+      readings['orientation'] = orient;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow
     }

--- a/lib/src/components/sensor/sensor.dart
+++ b/lib/src/components/sensor/sensor.dart
@@ -4,7 +4,7 @@ import '../../gen/common/v1/common.pb.dart';
 import '../../robot/client.dart';
 
 abstract class Sensor extends Resource {
-  static const Subtype subtype = Subtype(ResourceNamespaceRDK, ResourceTypeComponent, "sensor");
+  static const Subtype subtype = Subtype(ResourceNamespaceRDK, ResourceTypeComponent, 'sensor');
 
   @override
   String name;

--- a/lib/src/components/servo/servo.dart
+++ b/lib/src/components/servo/servo.dart
@@ -4,7 +4,7 @@ import 'package:viam_sdk/src/resource/base.dart';
 import '../../robot/client.dart';
 
 abstract class Servo extends Resource {
-  static const Subtype subtype = Subtype(ResourceNamespaceRDK, ResourceTypeComponent, "servo");
+  static const Subtype subtype = Subtype(ResourceNamespaceRDK, ResourceTypeComponent, 'servo');
 
   @override
   String name;

--- a/lib/src/domain/auth_rdk/service/auth_api_service.dart
+++ b/lib/src/domain/auth_rdk/service/auth_api_service.dart
@@ -2,7 +2,7 @@ import 'package:grpc/grpc_connection_interface.dart';
 import 'package:viam_sdk/src/domain/auth_rdk/model/auth_data.dart';
 import 'package:viam_sdk/src/gen/proto/rpc/v1/auth.pbgrpc.dart';
 
-const type = "robot-location-secret";
+const type = 'robot-location-secret';
 
 class ViamAuthService {
   final ClientChannelBase _client;
@@ -23,7 +23,7 @@ class ViamAuthService {
       type: type,
       payload: secure,
     );
-    authRequest.entity = url.replaceAll(RegExp(r"^(.*:\/\/)/"), "");
+    authRequest.entity = url.replaceAll(RegExp(r'^(.*:\/\/)/'), '');
 
     authRequest.credentials = credentials;
 

--- a/lib/src/domain/web_rtc/web_rtc_client/web_rtc_client_connection.dart
+++ b/lib/src/domain/web_rtc/web_rtc_client/web_rtc_client_connection.dart
@@ -4,10 +4,10 @@ import 'dart:async';
 import 'package:fixnum/fixnum.dart';
 import 'package:grpc/grpc.dart';
 import 'package:grpc/grpc_connection_interface.dart';
-import 'package:viam_sdk/src/gen/google/protobuf/duration.pb.dart' as grpc_duration;
-import 'package:viam_sdk/src/gen/proto/rpc/webrtc/v1/grpc.pb.dart' as grpc;
 import 'package:viam_sdk/src/domain/web_rtc/web_rtc_client/web_rtc_client.dart';
 import 'package:viam_sdk/src/domain/web_rtc/web_rtc_client/web_rtc_transport_stream.dart';
+import 'package:viam_sdk/src/gen/google/protobuf/duration.pb.dart' as grpc_duration;
+import 'package:viam_sdk/src/gen/proto/rpc/webrtc/v1/grpc.pb.dart' as grpc;
 
 class WebRtcClientConnection extends ClientConnection {
   final WebRtcClientChannel webRtcClientChannel;
@@ -15,13 +15,13 @@ class WebRtcClientConnection extends ClientConnection {
   WebRtcClientConnection(this.webRtcClientChannel);
 
   @override
-  String get authority => "";
+  String get authority => '';
 
   @override
   set onStateChanged(void Function(ConnectionState p1) cb) {}
 
   @override
-  String get scheme => "";
+  String get scheme => '';
 
   @override
   void dispatchCall(ClientCall<dynamic, dynamic> call) {

--- a/lib/src/resource/base.dart
+++ b/lib/src/resource/base.dart
@@ -1,8 +1,8 @@
 import 'package:viam_sdk/src/proto/common.dart';
 
-const String ResourceNamespaceRDK = "rdk";
-const String ResourceTypeComponent = "component";
-const String ResourceTypeService = "service";
+const String ResourceNamespaceRDK = 'rdk';
+const String ResourceTypeComponent = 'component';
+const String ResourceTypeService = 'service';
 
 class Subtype {
   final String namespace, resourceType, resourceSubtype;
@@ -19,7 +19,7 @@ class Subtype {
   }
 
   @override
-  String toString() => "${namespace}:${resourceType}:${resourceSubtype}";
+  String toString() => '${namespace}:${resourceType}:${resourceSubtype}';
 
   @override
   int get hashCode => Object.hash(namespace, resourceType, resourceSubtype);

--- a/lib/src/resource/manager.dart
+++ b/lib/src/resource/manager.dart
@@ -10,7 +10,7 @@ class ResourceManager {
     if (this.resources.containsKey(name)) {
       throw Exception('Duplicate registration of resource in manager');
     }
-    final shortName = name.name.split(":").last;
+    final shortName = name.name.split(':').last;
     if (!(this._shortToLongName[shortName]?.contains(name) ?? true)) {
       var names = this._shortToLongName[shortName] ?? [];
       names.add(name);

--- a/test/unit_test/domain/sensor/model/get_readings_response_to_viam_sensor_readings_mapper_test.dart
+++ b/test/unit_test/domain/sensor/model/get_readings_response_to_viam_sensor_readings_mapper_test.dart
@@ -7,7 +7,7 @@ import 'package:viam_sdk/src/gen/service/sensors/v1/sensors.pb.dart';
 
 void main() {
   group('When map from GetReadingsResponse to ViamSensorReadings', () {
-    test("mapper return correct values ", () {
+    test('mapper return correct values ', () {
       final dto = Readings(
         name: ResourceName(
           namespace: 'namespace',


### PR DESCRIPTION
This is a dart style guide nit pr. Cleaning up some warnings dart is generating about double quotes, where we ought to [prefer single quotes](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#prefer-single-quotes-for-strings).

We could configure to prefer double quotes, I don't have a strong preference either way, just getting things in line with current linter configuration for now.