### PR TITLE
align example and sdk lint & analysis settings

### DIFF
--- a/example/viam_example_app/.vscode/settings.json
+++ b/example/viam_example_app/.vscode/settings.json
@@ -1,3 +1,13 @@
 {
-    "cmake.configureOnOpen": false
+    "dart.lineLength": 140,
+    "[dart]": {
+        "editor.rulers": [
+            140
+        ],
+    },
+    "cmake.configureOnOpen": false,
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": true
+    },
 }

--- a/example/viam_example_app/analysis_options.yaml
+++ b/example/viam_example_app/analysis_options.yaml
@@ -1,6 +1,24 @@
-include: package:flutter_lints/flutter.yaml
-
 linter:
   rules:
-    avoid_print: false
-    prefer_single_quotes: true
+    - always_declare_return_types
+    - avoid_catching_errors
+    - avoid_dynamic_calls
+    - avoid_field_initializers_in_const_classes
+    - avoid_returning_null
+    - avoid_returning_null_for_future
+    - avoid_slow_async_io
+    - avoid_type_to_string
+    - avoid_void_async
+    - camel_case_types
+    - cancel_subscriptions
+    - cast_nullable_to_non_nullable
+    - close_sinks
+    - invariant_booleans
+    - literal_only_boolean_expressions
+    - no_adjacent_strings_in_list
+    - only_throw_errors
+    - throw_in_finally
+    - unawaited_futures
+    - unnecessary_statements
+    - unnecessary_await_in_return
+    - prefer_single_quotes


### PR DESCRIPTION
This PR pulls in the lint and analysis settings from the SDK into the nested example project.

I like to run the example project from VS code by opening that project in its own window, I was running into inconsistencies in dart formatting the same file from the example project vs code window and the SDK vs code window, this resolves those inconsistencies in the auto formatting on save. As well as aligns the lint errors / warning that will be surfaced.
