### PR TITLE
servo method rename

### DIFF
--- a/example/viam_example_app/lib/screens/servo.dart
+++ b/example/viam_example_app/lib/screens/servo.dart
@@ -7,8 +7,7 @@ class ServoScreen extends StatefulWidget {
   final Servo servo;
   final ResourceName resourceName;
 
-  const ServoScreen({Key? key, required this.servo, required this.resourceName})
-      : super(key: key);
+  const ServoScreen({Key? key, required this.servo, required this.resourceName}) : super(key: key);
 
   @override
   State<ServoScreen> createState() {
@@ -28,7 +27,7 @@ class _ServoScreenState extends State<ServoScreen> {
   }
 
   void _getPosition() async {
-    angle = await widget.servo.getPosition();
+    angle = await widget.servo.position();
     setState(() {});
   }
 
@@ -57,8 +56,7 @@ class _ServoScreenState extends State<ServoScreen> {
           padding: const EdgeInsets.all(16.0),
           child: Column(
             children: [
-              const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 8, horizontal: 0)),
+              const Padding(padding: EdgeInsets.symmetric(vertical: 8, horizontal: 0)),
               PlatformText(
                 '${widget.resourceName.namespace}:${widget.resourceName.type}:${widget.resourceName.subtype}/${widget.resourceName.name}',
                 style: const TextStyle(fontWeight: FontWeight.w300),
@@ -72,8 +70,7 @@ class _ServoScreenState extends State<ServoScreen> {
               Row(
                 children: [
                   ElevatedButton(
-                    onPressed:
-                        (angle - 10 < 0) ? null : () => _move(angle - 10),
+                    onPressed: (angle - 10 < 0) ? null : () => _move(angle - 10),
                     child: const Text('-10'),
                   ),
                   const SizedBox(width: 16),
@@ -83,14 +80,12 @@ class _ServoScreenState extends State<ServoScreen> {
                   ),
                   const SizedBox(width: 16),
                   ElevatedButton(
-                    onPressed:
-                        (angle + 1 > 180) ? null : () => _move(angle + 1),
+                    onPressed: (angle + 1 > 180) ? null : () => _move(angle + 1),
                     child: const Text('1'),
                   ),
                   const SizedBox(width: 16),
                   ElevatedButton(
-                    onPressed:
-                        (angle + 10 > 180) ? null : () => _move(angle + 10),
+                    onPressed: (angle + 10 > 180) ? null : () => _move(angle + 10),
                     child: const Text('10'),
                   ),
                 ],
@@ -113,11 +108,7 @@ class _ServoScreenState extends State<ServoScreen> {
                   ),
                   const SizedBox(width: 16),
                   ElevatedButton(
-                    onPressed: (moveTo.isEmpty ||
-                            int.parse(moveTo) > 180 ||
-                            int.parse(moveTo) < 0)
-                        ? null
-                        : () => _move(int.parse(moveTo)),
+                    onPressed: (moveTo.isEmpty || int.parse(moveTo) > 180 || int.parse(moveTo) < 0) ? null : () => _move(int.parse(moveTo)),
                     child: const Text('Go'),
                   ),
                   const Spacer(),
@@ -127,9 +118,7 @@ class _ServoScreenState extends State<ServoScreen> {
               Row(
                 children: [
                   ElevatedButton(
-                    style: ButtonStyle(
-                        backgroundColor:
-                            MaterialStateProperty.all<Color>(Colors.red)),
+                    style: ButtonStyle(backgroundColor: MaterialStateProperty.all<Color>(Colors.red)),
                     onPressed: () => _stop(),
                     child: const Text('STOP'),
                   ),

--- a/lib/src/components/servo/client.dart
+++ b/lib/src/components/servo/client.dart
@@ -16,7 +16,7 @@ class ServoClient extends Servo {
   }
 
   @override
-  Future<int> getPosition({Map<String, dynamic>? extra}) async {
+  Future<int> position({Map<String, dynamic>? extra}) async {
     final response = await _client.getPosition(GetPositionRequest(name: name, extra: extra?.toStruct()));
     return response.positionDeg;
   }

--- a/lib/src/components/servo/servo.dart
+++ b/lib/src/components/servo/servo.dart
@@ -19,7 +19,7 @@ abstract class Servo extends Resource {
   Future<void> move(int angle, {Map<String, dynamic>? extra});
 
   /// Get the current angle (degrees) of the [Servo].
-  Future<int> getPosition({Map<String, dynamic>? extra});
+  Future<int> position({Map<String, dynamic>? extra});
 
   /// Stop the [Servo]. It is assumed that the servo stops immediately.
   Future<void> stop({Map<String, dynamic>? extra});


### PR DESCRIPTION
following dart naming guidelines, removing `get`. as well as some misc formatting changes now that format settings are aligned inside example project.