### PR TITLE
Sensor & Movement Sensor rename

### DIFF
--- a/example/viam_example_app/lib/screens/sensor.dart
+++ b/example/viam_example_app/lib/screens/sensor.dart
@@ -18,7 +18,7 @@ class _SensorScreenState extends State<SensorScreen> {
   Map<String, dynamic> readings = {};
 
   void _getReadings() {
-    final readingsFut = widget.sensor.getReadings();
+    final readingsFut = widget.sensor.readings();
     readingsFut.then((value) => setState(
           () {
             readings = value;

--- a/lib/src/components/movement_sensor/client.dart
+++ b/lib/src/components/movement_sensor/client.dart
@@ -12,54 +12,54 @@ class MovementSensorClient extends MovementSensor {
   MovementSensorClient(super.name, this._channel) : _client = MovementSensorServiceClient(_channel);
 
   @override
-  Future<Position> getPosition({Map<String, dynamic>? extra}) async {
+  Future<Position> position({Map<String, dynamic>? extra}) async {
     final response = await _client.getPosition(GetPositionRequest(name: name, extra: extra?.toStruct()));
     return Position(response.coordinate, response.altitudeMm);
   }
 
   @override
-  Future<Vector3> getLinearVelocity({Map<String, dynamic>? extra}) async {
+  Future<Vector3> linearVelocity({Map<String, dynamic>? extra}) async {
     final response = await _client.getLinearVelocity(GetLinearVelocityRequest(name: name, extra: extra?.toStruct()));
     return response.linearVelocity;
   }
 
   @override
-  Future<Vector3> getAngularVelocity({Map<String, dynamic>? extra}) async {
+  Future<Vector3> angularVelocity({Map<String, dynamic>? extra}) async {
     final response = await _client.getAngularVelocity(GetAngularVelocityRequest(name: name, extra: extra?.toStruct()));
     return response.angularVelocity;
   }
 
   @override
-  Future<Vector3> getLinearAcceleration({Map<String, dynamic>? extra}) async {
+  Future<Vector3> linearAcceleration({Map<String, dynamic>? extra}) async {
     final response = await _client.getLinearAcceleration(GetLinearAccelerationRequest(name: name, extra: extra?.toStruct()));
     return response.linearAcceleration;
   }
 
   @override
-  Future<double> getCompassHeading({Map<String, dynamic>? extra}) async {
+  Future<double> compassHeading({Map<String, dynamic>? extra}) async {
     final response = await _client.getCompassHeading(GetCompassHeadingRequest(name: name, extra: extra?.toStruct()));
     return response.value;
   }
 
   @override
-  Future<Orientation> getOrientation({Map<String, dynamic>? extra}) async {
+  Future<Orientation> orientation({Map<String, dynamic>? extra}) async {
     final response = await _client.getOrientation(GetOrientationRequest(name: name, extra: extra?.toStruct()));
     return response.orientation;
   }
 
   @override
-  Future<Properties> getProperties({Map<String, dynamic>? extra}) async {
+  Future<Properties> properties({Map<String, dynamic>? extra}) async {
     return await _client.getProperties(GetPropertiesRequest(name: name, extra: extra?.toStruct()));
   }
 
   @override
-  Future<Map<String, double>> getAccuracy({Map<String, dynamic>? extra}) async {
+  Future<Map<String, double>> accuracy({Map<String, dynamic>? extra}) async {
     final response = await _client.getAccuracy(GetAccuracyRequest(name: name, extra: extra?.toStruct()));
     return response.accuracyMm;
   }
 
   @override
-  Future<Map<String, dynamic>> getReadings({Map<String, dynamic>? extra}) {
+  Future<Map<String, dynamic>> readings({Map<String, dynamic>? extra}) {
     return super.getReadings(extra: extra);
   }
 }

--- a/lib/src/components/movement_sensor/movement_sensor.dart
+++ b/lib/src/components/movement_sensor/movement_sensor.dart
@@ -20,34 +20,34 @@ abstract class MovementSensor extends Sensor {
   MovementSensor(super.name);
 
   /// Get the current GeoPoint (latitude, longitude) and altitude (mm)
-  Future<Position> getPosition({Map<String, dynamic>? extra});
+  Future<Position> position({Map<String, dynamic>? extra});
 
   /// Get the current linear velocity as a ``Vector3`` with x, y, and z axes represented in mm/sec
-  Future<Vector3> getLinearVelocity({Map<String, dynamic>? extra});
+  Future<Vector3> linearVelocity({Map<String, dynamic>? extra});
 
   /// Get the current angular velocity as a ``Vector3`` with x, y, and z axes represented in radians/sec
-  Future<Vector3> getAngularVelocity({Map<String, dynamic>? extra});
+  Future<Vector3> angularVelocity({Map<String, dynamic>? extra});
 
   /// Get the current linear acceleration as a ``Vector3`` with x, y, and z axes represented in mm/sec^2
-  Future<Vector3> getLinearAcceleration({Map<String, dynamic>? extra});
+  Future<Vector3> linearAcceleration({Map<String, dynamic>? extra});
 
   /// Get the current compass heading in degrees
-  Future<double> getCompassHeading({Map<String, dynamic>? extra});
+  Future<double> compassHeading({Map<String, dynamic>? extra});
 
   /// Get the current orientation
-  Future<Orientation> getOrientation({Map<String, dynamic>? extra});
+  Future<Orientation> orientation({Map<String, dynamic>? extra});
 
   /// Get the supported properties of this sensor
-  Future<Properties> getProperties({Map<String, dynamic>? extra});
+  Future<Properties> properties({Map<String, dynamic>? extra});
 
   /// Get the accuracy of the various sensors
-  Future<Map<String, double>> getAccuracy({Map<String, dynamic>? extra});
+  Future<Map<String, double>> accuracy({Map<String, dynamic>? extra});
 
   @override
   Future<Map<String, dynamic>> getReadings({Map<String, dynamic>? extra}) async {
     Map<String, dynamic> readings = {};
     try {
-      Position pos = await getPosition(extra: extra);
+      Position pos = await position(extra: extra);
       readings['position'] = pos.coordinates;
       readings['altitude'] = pos.altitude;
     } catch (exception) {
@@ -56,35 +56,35 @@ abstract class MovementSensor extends Sensor {
     }
 
     try {
-      Vector3 lv = await getLinearVelocity(extra: extra);
+      Vector3 lv = await linearVelocity(extra: extra);
       readings['linear_velocity'] = lv;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow
     }
 
     try {
-      Vector3 av = await getAngularVelocity(extra: extra);
+      Vector3 av = await angularVelocity(extra: extra);
       readings['angular_velocity'] = av;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow
     }
 
     try {
-      Vector3 la = await getLinearAcceleration(extra: extra);
+      Vector3 la = await linearAcceleration(extra: extra);
       readings['linear_acceleration'] = la;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow
     }
 
     try {
-      double comp = await getCompassHeading(extra: extra);
+      double comp = await compassHeading(extra: extra);
       readings['compass'] = comp;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow
     }
 
     try {
-      Orientation orient = await getOrientation(extra: extra);
+      Orientation orient = await orientation(extra: extra);
       readings['orientation'] = orient;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow

--- a/lib/src/components/sensor/client.dart
+++ b/lib/src/components/sensor/client.dart
@@ -11,7 +11,7 @@ class SensorClient extends Sensor {
   SensorClient(super.name, this._channel) : _client = SensorServiceClient(_channel);
 
   @override
-  Future<Map<String, dynamic>> getReadings({Map<String, dynamic>? extra}) async {
+  Future<Map<String, dynamic>> readings({Map<String, dynamic>? extra}) async {
     final response = await _client.getReadings(GetReadingsRequest(name: name, extra: extra?.toStruct()));
     return response.readings.map((key, value) => MapEntry(key, value.toPrimitive()));
   }

--- a/lib/src/components/sensor/sensor.dart
+++ b/lib/src/components/sensor/sensor.dart
@@ -12,7 +12,7 @@ abstract class Sensor extends Resource {
   Sensor(this.name);
 
   /// Obtain the measurements/data specific to this [Sensor]
-  Future<Map<String, dynamic>> getReadings({Map<String, dynamic>? extra});
+  Future<Map<String, dynamic>> readings({Map<String, dynamic>? extra});
 
   static ResourceName getResourceName(String name) {
     return Sensor.subtype.getResourceName(name);


### PR DESCRIPTION
renaming methods in sensor & movement sensor to match dart style guide. (Avoid starting method names with 'get')