### PR TITLE
Motor Method Rename

### DIFF
--- a/lib/src/components/motor/client.dart
+++ b/lib/src/components/motor/client.dart
@@ -8,53 +8,37 @@ class MotorClient extends Motor {
   ClientChannelBase _channel;
   MotorServiceClient _client;
 
-  MotorClient(super.name, this._channel)
-      : _client = MotorServiceClient(_channel);
+  MotorClient(super.name, this._channel) : _client = MotorServiceClient(_channel);
 
   @override
   Future<void> setPower(double powerPct, {Map<String, dynamic>? extra}) async {
-    await _client.setPower(SetPowerRequest(
-        name: name, powerPct: powerPct, extra: extra?.toStruct()));
+    await _client.setPower(SetPowerRequest(name: name, powerPct: powerPct, extra: extra?.toStruct()));
   }
 
   @override
-  Future<void> goFor(double rpm, double revolutions,
-      {Map<String, dynamic>? extra}) async {
-    await _client.goFor(GoForRequest(
-        name: name,
-        rpm: rpm,
-        revolutions: revolutions,
-        extra: extra?.toStruct()));
+  Future<void> goFor(double rpm, double revolutions, {Map<String, dynamic>? extra}) async {
+    await _client.goFor(GoForRequest(name: name, rpm: rpm, revolutions: revolutions, extra: extra?.toStruct()));
   }
 
   @override
-  Future<void> goTo(double rpm, double positionRevolutions,
-      {Map<String, dynamic>? extra}) async {
-    await _client.goTo(GoToRequest(
-        name: name,
-        rpm: rpm,
-        positionRevolutions: positionRevolutions,
-        extra: extra?.toStruct()));
+  Future<void> goTo(double rpm, double positionRevolutions, {Map<String, dynamic>? extra}) async {
+    await _client.goTo(GoToRequest(name: name, rpm: rpm, positionRevolutions: positionRevolutions, extra: extra?.toStruct()));
   }
 
   @override
-  Future<void> resetZeroPosition(double offset,
-      {Map<String, dynamic>? extra}) async {
-    await _client.resetZeroPosition(ResetZeroPositionRequest(
-        name: name, offset: offset, extra: extra?.toStruct()));
+  Future<void> resetZeroPosition(double offset, {Map<String, dynamic>? extra}) async {
+    await _client.resetZeroPosition(ResetZeroPositionRequest(name: name, offset: offset, extra: extra?.toStruct()));
   }
 
   @override
-  Future<double> getPosition({Map<String, dynamic>? extra}) async {
-    final result = await _client
-        .getPosition(GetPositionRequest(name: name, extra: extra?.toStruct()));
+  Future<double> position({Map<String, dynamic>? extra}) async {
+    final result = await _client.getPosition(GetPositionRequest(name: name, extra: extra?.toStruct()));
     return result.position;
   }
 
   @override
-  Future<MotorProperties> getProperties({Map<String, dynamic>? extra}) async {
-    final result = await _client.getProperties(
-        GetPropertiesRequest(name: name, extra: extra?.toStruct()));
+  Future<MotorProperties> properties({Map<String, dynamic>? extra}) async {
+    final result = await _client.getProperties(GetPropertiesRequest(name: name, extra: extra?.toStruct()));
     return MotorProperties.fromProto(result);
   }
 
@@ -64,9 +48,8 @@ class MotorClient extends Motor {
   }
 
   @override
-  Future<PowerState> isPowered({Map<String, dynamic>? extra}) async {
-    final result = await _client
-        .isPowered(IsPoweredRequest(name: name, extra: extra?.toStruct()));
+  Future<PowerState> powerState({Map<String, dynamic>? extra}) async {
+    final result = await _client.isPowered(IsPoweredRequest(name: name, extra: extra?.toStruct()));
     return PowerState.fromProto(result);
   }
 

--- a/lib/src/components/motor/motor.dart
+++ b/lib/src/components/motor/motor.dart
@@ -58,17 +58,17 @@ abstract class Motor extends Resource {
   /// Report the position of the motor based on its encoder.
   /// The value returned is the number of revolutions relative to its zero position.
   /// This method will raise an exception if position reporting is not supported by the motor.
-  Future<double> getPosition({Map<String, dynamic>? extra});
+  Future<double> position({Map<String, dynamic>? extra});
 
   /// Report a dictionary mapping optional properties to
   /// whether it is supported by this motor.
-  Future<MotorProperties> getProperties({Map<String, dynamic>? extra});
+  Future<MotorProperties> properties({Map<String, dynamic>? extra});
 
   /// Stop the motor immediately, without any gradual step down.
   Future<void> stop({Map<String, dynamic>? extra});
 
   /// Returns whether or not the motor is currently running.
-  Future<PowerState> isPowered({Map<String, dynamic>? extra});
+  Future<PowerState> powerState({Map<String, dynamic>? extra});
 
   /// Get if the [Motor] is currently moving.
   Future<bool> isMoving({Map<String, dynamic>? extra});


### PR DESCRIPTION
Renaming some methods in motor to follow dart guidelines.

Also some misc formatting changes were automatically included, these are no harm and should stop showing up now that i've dialed in analysis settings in the example app.