### PR TITLE
Rename Camera Methods

### DIFF
--- a/example/viam_example_app/lib/screens/stream.dart
+++ b/example/viam_example_app/lib/screens/stream.dart
@@ -35,7 +35,7 @@ class _StreamScreenState extends State<StreamScreen> {
     setState(() {
       _imgLoaded = false;
     });
-    final imageFut = widget.camera.getImage();
+    final imageFut = widget.camera.image();
     imageFut.then((value) {
       final convertFut = convertImageToFlutterUi(value.image ?? img.Image.empty());
       convertFut.then((value) {
@@ -89,7 +89,7 @@ class _StreamScreenState extends State<StreamScreen> {
   }
 
   @override
-  deactivate() {
+  void deactivate() {
     super.deactivate();
     _renderer.dispose();
     widget.client.remove(widget.resourceName.name);

--- a/lib/src/components/camera/camera.dart
+++ b/lib/src/components/camera/camera.dart
@@ -28,13 +28,13 @@ abstract class Camera extends Resource {
   Camera(this.name);
 
   /// Get the next image from the camera.
-  Future<ViamImage> getImage({MimeType? mimeType});
+  Future<ViamImage> image({MimeType? mimeType});
 
   /// Get the next point cloud from the camera.
-  Future<ViamImage> getPointCloud();
+  Future<ViamImage> pointCloud();
 
   /// Get the camera's intrinsic parameters and the camera's distortion parameters.
-  Future<CameraProperties> getProperties();
+  Future<CameraProperties> properties();
 
   static ResourceName getResourceName(String name) {
     return Camera.subtype.getResourceName(name);

--- a/lib/src/components/camera/client.dart
+++ b/lib/src/components/camera/client.dart
@@ -11,7 +11,7 @@ class CameraClient extends Camera {
   CameraClient(super.name, this._channel) : _client = CameraServiceClient(_channel);
 
   @override
-  Future<ViamImage> getImage({MimeType? mimeType}) async {
+  Future<ViamImage> image({MimeType? mimeType}) async {
     final request = GetImageRequest(name: name, mimeType: mimeType?.name);
     final response = await _client.getImage(request);
     final actualMimeType = MimeType.fromString(response.mimeType);
@@ -19,7 +19,7 @@ class CameraClient extends Camera {
   }
 
   @override
-  Future<ViamImage> getPointCloud() async {
+  Future<ViamImage> pointCloud() async {
     final request = GetPointCloudRequest(name: name, mimeType: MimeType.pcd.name);
     final response = await _client.getPointCloud(request);
     final actualMimeType = MimeType.fromString(response.mimeType);
@@ -27,7 +27,7 @@ class CameraClient extends Camera {
   }
 
   @override
-  Future<CameraProperties> getProperties() async {
+  Future<CameraProperties> properties() async {
     final request = GetPropertiesRequest(name: name);
     final response = await _client.getProperties(request);
     return CameraProperties(response.supportsPcd, response.intrinsicParameters, response.distortionParameters);


### PR DESCRIPTION
Rename camera methods to follow dart guidelines.

Also included driveby fixing warning about not have a return type on `deactivate()`