### PR TITLE
fix int conversion crash

### DIFF
--- a/lib/src/components/board/board.dart
+++ b/lib/src/components/board/board.dart
@@ -13,7 +13,7 @@ class BoardStatus {
   factory BoardStatus.fromProto(common.BoardStatus pbBoardStatus) {
     BoardStatus boardStatus = BoardStatus(Map<String, int>(), Map<String, int>());
     pbBoardStatus.analogs.forEach((key, value) => boardStatus.analogs[key] = value.value);
-    pbBoardStatus.digitalInterrupts.forEach((key, value) => boardStatus.digitalInterrupts[key] = (value.value as int));
+    pbBoardStatus.digitalInterrupts.forEach((key, value) => boardStatus.digitalInterrupts[key] = (value.value.toInt()));
     return boardStatus;
   }
 }


### PR DESCRIPTION
this conversion wasn't working as expected and crashes when trying to view a board screen with digital interrupts.

Changing it to toInt() casts correctly and no longer crashes.