### PR TITLE
Prefer final locals

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,4 +29,4 @@ jobs:
         run: dart analyze --no-fatal-warnings
 
       - name: Run tests
-        run: flutter test
+        run: flutter test --concurrency=1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,4 +29,4 @@ jobs:
         run: dart analyze --no-fatal-warnings
 
       - name: Run tests
-        run: flutter test --concurrency=1
+        run: flutter test

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -22,6 +22,7 @@ linter:
     - unawaited_futures
     - unnecessary_statements
     - unnecessary_await_in_return
+    - prefer_final_locals
 
 analyzer:
   errors:

--- a/example/viam_example_app/lib/screens/stream.dart
+++ b/example/viam_example_app/lib/screens/stream.dart
@@ -59,14 +59,15 @@ class _StreamScreenState extends State<StreamScreen> {
       }
     }
 
-    ui.ImmutableBuffer buffer = await ui.ImmutableBuffer.fromUint8List(image.toUint8List());
+    final ui.ImmutableBuffer buffer = await ui.ImmutableBuffer.fromUint8List(image.toUint8List());
 
-    ui.ImageDescriptor id = ui.ImageDescriptor.raw(buffer, height: image.height, width: image.width, pixelFormat: ui.PixelFormat.rgba8888);
+    final ui.ImageDescriptor id =
+        ui.ImageDescriptor.raw(buffer, height: image.height, width: image.width, pixelFormat: ui.PixelFormat.rgba8888);
 
-    ui.Codec codec = await id.instantiateCodec(targetHeight: image.height, targetWidth: image.width);
+    final ui.Codec codec = await id.instantiateCodec(targetHeight: image.height, targetWidth: image.width);
 
-    ui.FrameInfo fi = await codec.getNextFrame();
-    ui.Image uiImage = fi.image;
+    final ui.FrameInfo fi = await codec.getNextFrame();
+    final ui.Image uiImage = fi.image;
 
     return uiImage;
   }

--- a/lib/src/components/arm/service.dart
+++ b/lib/src/components/arm/service.dart
@@ -21,49 +21,49 @@ class ArmService extends ArmServiceBase {
 
   @override
   Future<DoCommandResponse> doCommand(ServiceCall call, DoCommandRequest request) async {
-    final Arm arm = _armFromManager(request.name);
+    final arm = _armFromManager(request.name);
     final result = await arm.doCommand(request.command.toMap());
     return DoCommandResponse(result: result.toStruct());
   }
 
   @override
   Future<IsMovingResponse> isMoving(ServiceCall call, IsMovingRequest request) async {
-    final Arm arm = _armFromManager(request.name);
-    final bool isMoving = await arm.isMoving();
+    final arm = _armFromManager(request.name);
+    final isMoving = await arm.isMoving();
     return IsMovingResponse(isMoving: isMoving);
   }
 
   @override
   Future<StopResponse> stop(ServiceCall call, StopRequest request) async {
-    final Arm arm = _armFromManager(request.name);
+    final arm = _armFromManager(request.name);
     await arm.stop(extra: request.extra.toMap());
     return StopResponse();
   }
 
   @override
   Future<GetEndPositionResponse> getEndPosition(ServiceCall call, GetEndPositionRequest request) async {
-    final Arm arm = _armFromManager(request.name);
-    final Pose pose = await arm.endPosition(extra: request.extra.toMap());
+    final arm = _armFromManager(request.name);
+    final pose = await arm.endPosition(extra: request.extra.toMap());
     return GetEndPositionResponse(pose: pose);
   }
 
   @override
   Future<GetJointPositionsResponse> getJointPositions(ServiceCall call, GetJointPositionsRequest request) async {
-    final Arm arm = _armFromManager(request.name);
-    final JointPositions jointPositions = await arm.jointPositions(extra: request.extra.toMap());
+    final arm = _armFromManager(request.name);
+    final jointPositions = await arm.jointPositions(extra: request.extra.toMap());
     return GetJointPositionsResponse(positions: jointPositions);
   }
 
   @override
   Future<MoveToJointPositionsResponse> moveToJointPositions(ServiceCall call, MoveToJointPositionsRequest request) async {
-    final Arm arm = _armFromManager(request.name);
+    final arm = _armFromManager(request.name);
     await arm.moveToJointPositions(request.positions, extra: request.extra.toMap());
     return MoveToJointPositionsResponse();
   }
 
   @override
   Future<MoveToPositionResponse> moveToPosition(ServiceCall call, MoveToPositionRequest request) async {
-    final Arm arm = _armFromManager(request.name);
+    final arm = _armFromManager(request.name);
     await arm.moveToPosition(request.to, extra: request.extra.toMap());
     return MoveToPositionResponse();
   }

--- a/lib/src/components/base/client.dart
+++ b/lib/src/components/base/client.dart
@@ -17,7 +17,7 @@ class BaseClient extends Base {
 
   @override
   Future<bool> isMoving() async {
-    var response = await _client.isMoving(IsMovingRequest(name: name));
+    final response = await _client.isMoving(IsMovingRequest(name: name));
     return response.isMoving;
   }
 

--- a/lib/src/components/base/service.dart
+++ b/lib/src/components/base/service.dart
@@ -21,49 +21,49 @@ class BaseService extends BaseServiceBase {
 
   @override
   Future<MoveStraightResponse> moveStraight(ServiceCall call, MoveStraightRequest request) async {
-    Base base = _fromManager(request.name);
+    final base = _fromManager(request.name);
     await base.moveStraight(request.distanceMm.toInt(), request.mmPerSec, extra: request.extra.toMap());
     return MoveStraightResponse();
   }
 
   @override
   Future<SpinResponse> spin(ServiceCall call, SpinRequest request) async {
-    Base base = _fromManager(request.name);
+    final base = _fromManager(request.name);
     await base.spin(request.angleDeg, request.degsPerSec, extra: request.extra.toMap());
     return SpinResponse();
   }
 
   @override
   Future<SetPowerResponse> setPower(ServiceCall call, SetPowerRequest request) async {
-    Base base = _fromManager(request.name);
+    final base = _fromManager(request.name);
     await base.setPower(request.linear, request.angular, extra: request.extra.toMap());
     return SetPowerResponse();
   }
 
   @override
   Future<SetVelocityResponse> setVelocity(ServiceCall call, SetVelocityRequest request) async {
-    Base base = _fromManager(request.name);
+    final base = _fromManager(request.name);
     await base.setVelocity(request.linear, request.angular, extra: request.extra.toMap());
     return SetVelocityResponse();
   }
 
   @override
   Future<StopResponse> stop(ServiceCall call, StopRequest request) async {
-    Base base = _fromManager(request.name);
+    final base = _fromManager(request.name);
     await base.stop(extra: request.extra.toMap());
     return StopResponse();
   }
 
   @override
   Future<IsMovingResponse> isMoving(ServiceCall call, IsMovingRequest request) async {
-    Base base = _fromManager(request.name);
+    final base = _fromManager(request.name);
     final result = await base.isMoving();
     return IsMovingResponse(isMoving: result);
   }
 
   @override
   Future<DoCommandResponse> doCommand(ServiceCall call, DoCommandRequest request) async {
-    Base base = _fromManager(request.name);
+    final base = _fromManager(request.name);
     final result = await base.doCommand(request.command.toMap());
     return DoCommandResponse(result: result.toStruct());
   }

--- a/lib/src/components/board/board.dart
+++ b/lib/src/components/board/board.dart
@@ -13,14 +13,14 @@ class BoardStatus {
   const BoardStatus(this.analogs, this.digitalInterrupts);
 
   factory BoardStatus.fromProto(common.BoardStatus pbBoardStatus) {
-    BoardStatus boardStatus = const BoardStatus(<String, int>{}, <String, int>{});
+    const boardStatus = BoardStatus(<String, int>{}, <String, int>{});
     pbBoardStatus.analogs.forEach((key, value) => boardStatus.analogs[key] = value.value);
     pbBoardStatus.digitalInterrupts.forEach((key, value) => boardStatus.digitalInterrupts[key] = (value.value.toInt()));
     return boardStatus;
   }
 
   common.BoardStatus get proto {
-    common.BoardStatus pbBoardStatus = common.BoardStatus();
+    final pbBoardStatus = common.BoardStatus();
     analogs.forEach((key, value) => pbBoardStatus.analogs[key] = AnalogStatus(value: value));
     digitalInterrupts.forEach((key, value) => pbBoardStatus.digitalInterrupts[key] = DigitalInterruptStatus(value: Int64(value)));
     return pbBoardStatus;

--- a/lib/src/components/board/client.dart
+++ b/lib/src/components/board/client.dart
@@ -24,7 +24,7 @@ class BoardClient extends Board {
 
   @override
   Future<BoardStatus> status({Map<String, dynamic>? extra}) async {
-    var response = await _client.status(StatusRequest(name: name, extra: extra?.toStruct()));
+    final response = await _client.status(StatusRequest(name: name, extra: extra?.toStruct()));
     return BoardStatus.fromProto(response.status);
   }
 
@@ -35,13 +35,13 @@ class BoardClient extends Board {
 
   @override
   Future<bool> gpio(String pin, {Map<String, dynamic>? extra}) async {
-    var response = await _client.getGPIO(GetGPIORequest(name: name, extra: extra?.toStruct()));
+    final response = await _client.getGPIO(GetGPIORequest(name: name, extra: extra?.toStruct()));
     return response.high;
   }
 
   @override
   Future<double> pwm(String pin, {Map<String, dynamic>? extra}) async {
-    var response = await _client.pWM(PWMRequest(name: name, extra: extra?.toStruct()));
+    final response = await _client.pWM(PWMRequest(name: name, extra: extra?.toStruct()));
     return response.dutyCyclePct;
   }
 
@@ -52,7 +52,7 @@ class BoardClient extends Board {
 
   @override
   Future<int> pwmFrequency({Map<String, dynamic>? extra}) async {
-    var response = await _client.pWMFrequency(PWMFrequencyRequest(name: name, extra: extra?.toStruct()));
+    final response = await _client.pWMFrequency(PWMFrequencyRequest(name: name, extra: extra?.toStruct()));
     return response.frequencyHz as int;
   }
 
@@ -63,14 +63,14 @@ class BoardClient extends Board {
 
   @override
   Future<int> analogReaderValue(String analogReaderName, {Map<String, dynamic>? extra}) async {
-    var response = await _client
+    final response = await _client
         .readAnalogReader(ReadAnalogReaderRequest(boardName: name, analogReaderName: analogReaderName, extra: extra?.toStruct()));
     return response.value;
   }
 
   @override
   Future<int> digitalInterruptValue(String digitalInterruptName, {Map<String, dynamic>? extra}) async {
-    var response = await _client.getDigitalInterruptValue(
+    final response = await _client.getDigitalInterruptValue(
         GetDigitalInterruptValueRequest(boardName: name, digitalInterruptName: digitalInterruptName, extra: extra?.toStruct()));
     return response.value as int;
   }

--- a/lib/src/components/board/service.dart
+++ b/lib/src/components/board/service.dart
@@ -22,78 +22,78 @@ class BoardService extends BoardServiceBase {
 
   @override
   Future<common.DoCommandResponse> doCommand(ServiceCall call, common.DoCommandRequest request) async {
-    final Board board = _fromManager(request.name);
+    final board = _fromManager(request.name);
     final result = await board.doCommand(request.command.toMap());
     return common.DoCommandResponse(result: result.toStruct());
   }
 
   @override
   Future<GetDigitalInterruptValueResponse> getDigitalInterruptValue(ServiceCall call, GetDigitalInterruptValueRequest request) async {
-    final Board board = _fromManager(request.boardName);
+    final board = _fromManager(request.boardName);
     final value = await board.digitalInterruptValue(request.digitalInterruptName, extra: request.extra.toMap());
     return GetDigitalInterruptValueResponse(value: Int64(value));
   }
 
   @override
   Future<GetGPIOResponse> getGPIO(ServiceCall call, GetGPIORequest request) async {
-    final Board board = _fromManager(request.name);
+    final board = _fromManager(request.name);
     final high = await board.gpio(request.pin, extra: request.extra.toMap());
     return GetGPIOResponse(high: high);
   }
 
   @override
   Future<PWMResponse> pWM(ServiceCall call, PWMRequest request) async {
-    final Board board = _fromManager(request.name);
+    final board = _fromManager(request.name);
     final dutyCyclePct = await board.pwm(request.pin, extra: request.extra.toMap());
     return PWMResponse(dutyCyclePct: dutyCyclePct);
   }
 
   @override
   Future<PWMFrequencyResponse> pWMFrequency(ServiceCall call, PWMFrequencyRequest request) async {
-    final Board board = _fromManager(request.name);
+    final board = _fromManager(request.name);
     final frequencyHz = await board.pwmFrequency(extra: request.extra.toMap());
     return PWMFrequencyResponse(frequencyHz: Int64(frequencyHz));
   }
 
   @override
   Future<ReadAnalogReaderResponse> readAnalogReader(ServiceCall call, ReadAnalogReaderRequest request) async {
-    final Board board = _fromManager(request.boardName);
+    final board = _fromManager(request.boardName);
     final value = await board.analogReaderValue(request.analogReaderName, extra: request.extra.toMap());
     return ReadAnalogReaderResponse(value: value);
   }
 
   @override
   Future<SetGPIOResponse> setGPIO(ServiceCall call, SetGPIORequest request) async {
-    final Board board = _fromManager(request.name);
+    final board = _fromManager(request.name);
     await board.setGpioState(request.pin, request.high, extra: request.extra.toMap());
     return SetGPIOResponse();
   }
 
   @override
   Future<SetPWMResponse> setPWM(ServiceCall call, SetPWMRequest request) async {
-    final Board board = _fromManager(request.name);
+    final board = _fromManager(request.name);
     await board.setPwm(request.pin, request.dutyCyclePct, extra: request.extra.toMap());
     return SetPWMResponse();
   }
 
   @override
   Future<SetPWMFrequencyResponse> setPWMFrequency(ServiceCall call, SetPWMFrequencyRequest request) async {
-    final Board board = _fromManager(request.name);
+    final board = _fromManager(request.name);
     await board.setPwmFrequency(request.pin, request.frequencyHz.toInt(), extra: request.extra.toMap());
     return SetPWMFrequencyResponse();
   }
 
   @override
   Future<SetPowerModeResponse> setPowerMode(ServiceCall call, SetPowerModeRequest request) async {
-    final Board board = _fromManager(request.name);
+    final board = _fromManager(request.name);
     await board.setPowerMode(request.powerMode, request.duration.seconds.toInt(), request.duration.nanos, extra: request.extra.toMap());
     return SetPowerModeResponse();
   }
 
   @override
   Future<StatusResponse> status(ServiceCall call, StatusRequest request) async {
-    final Board board = _fromManager(request.name);
-    final BoardStatus boardStatus = await board.status(extra: request.extra.toMap());
+    final board = _fromManager(request.name);
+    final boardStatus = await board.status(extra: request.extra.toMap());
     return StatusResponse(status: boardStatus.proto);
   }
 }

--- a/lib/src/components/motor/service.dart
+++ b/lib/src/components/motor/service.dart
@@ -11,7 +11,7 @@ class MotorService extends MotorServiceBase {
 
   MotorService(this._manager);
 
-  Motor _motorFromManager(String name) {
+  Motor _fromManager(String name) {
     try {
       return _manager.getResource(Motor.getResourceName(name));
     } catch (e) {
@@ -21,70 +21,70 @@ class MotorService extends MotorServiceBase {
 
   @override
   Future<DoCommandResponse> doCommand(ServiceCall call, DoCommandRequest request) async {
-    Motor motor = _motorFromManager(request.name);
-    var result = await motor.doCommand(request.command.toMap());
+    final motor = _fromManager(request.name);
+    final result = await motor.doCommand(request.command.toMap());
     return DoCommandResponse(result: result.toStruct());
   }
 
   @override
   Future<GetPositionResponse> getPosition(ServiceCall call, GetPositionRequest request) async {
-    Motor motor = _motorFromManager(request.name);
-    final double position = await motor.position(extra: request.extra.toMap());
+    final motor = _fromManager(request.name);
+    final position = await motor.position(extra: request.extra.toMap());
     return GetPositionResponse(position: position);
   }
 
   @override
   Future<IsMovingResponse> isMoving(ServiceCall call, IsMovingRequest request) async {
-    Motor motor = _motorFromManager(request.name);
-    final bool isMoving = await motor.isMoving();
+    final motor = _fromManager(request.name);
+    final isMoving = await motor.isMoving();
     return IsMovingResponse(isMoving: isMoving);
   }
 
   @override
   Future<StopResponse> stop(ServiceCall call, StopRequest request) async {
-    Motor motor = _motorFromManager(request.name);
+    final motor = _fromManager(request.name);
     await motor.stop(extra: request.extra.toMap());
     return StopResponse();
   }
 
   @override
   Future<GetPropertiesResponse> getProperties(ServiceCall call, GetPropertiesRequest request) async {
-    Motor motor = _motorFromManager(request.name);
-    final MotorProperties properties = await motor.properties(extra: request.extra.toMap());
+    final motor = _fromManager(request.name);
+    final properties = await motor.properties(extra: request.extra.toMap());
     return GetPropertiesResponse(positionReporting: properties.positionReporting);
   }
 
   @override
   Future<GoForResponse> goFor(ServiceCall call, GoForRequest request) async {
-    Motor motor = _motorFromManager(request.name);
+    final motor = _fromManager(request.name);
     await motor.goFor(request.rpm, request.revolutions, extra: request.extra.toMap());
     return GoForResponse();
   }
 
   @override
   Future<GoToResponse> goTo(ServiceCall call, GoToRequest request) async {
-    Motor motor = _motorFromManager(request.name);
+    final motor = _fromManager(request.name);
     await motor.goTo(request.rpm, request.positionRevolutions, extra: request.extra.toMap());
     return GoToResponse();
   }
 
   @override
   Future<IsPoweredResponse> isPowered(ServiceCall call, IsPoweredRequest request) async {
-    Motor motor = _motorFromManager(request.name);
-    final PowerState powerState = await motor.powerState(extra: request.extra.toMap());
+    final motor = _fromManager(request.name);
+    final powerState = await motor.powerState(extra: request.extra.toMap());
     return IsPoweredResponse(isOn: powerState.isOn, powerPct: powerState.powerPct);
   }
 
   @override
   Future<ResetZeroPositionResponse> resetZeroPosition(ServiceCall call, ResetZeroPositionRequest request) async {
-    Motor motor = _motorFromManager(request.name);
+    final motor = _fromManager(request.name);
     await motor.resetZeroPosition(request.offset, extra: request.extra.toMap());
     return ResetZeroPositionResponse();
   }
 
   @override
   Future<SetPowerResponse> setPower(ServiceCall call, SetPowerRequest request) async {
-    Motor motor = _motorFromManager(request.name);
+    final motor = _fromManager(request.name);
     await motor.setPower(request.powerPct, extra: request.extra.toMap());
     return SetPowerResponse();
   }

--- a/lib/src/components/movement_sensor/movement_sensor.dart
+++ b/lib/src/components/movement_sensor/movement_sensor.dart
@@ -43,9 +43,9 @@ abstract class MovementSensor extends Sensor {
 
   @override
   Future<Map<String, dynamic>> readings({Map<String, dynamic>? extra}) async {
-    Map<String, dynamic> readings = {};
+    final Map<String, dynamic> readings = {};
     try {
-      Position pos = await position(extra: extra);
+      final Position pos = await position(extra: extra);
       readings['position'] = pos.coordinates;
       readings['altitude'] = pos.altitude;
     } catch (exception) {
@@ -54,35 +54,35 @@ abstract class MovementSensor extends Sensor {
     }
 
     try {
-      Vector3 lv = await linearVelocity(extra: extra);
+      final lv = await linearVelocity(extra: extra);
       readings['linear_velocity'] = lv;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow
     }
 
     try {
-      Vector3 av = await angularVelocity(extra: extra);
+      final av = await angularVelocity(extra: extra);
       readings['angular_velocity'] = av;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow
     }
 
     try {
-      Vector3 la = await linearAcceleration(extra: extra);
+      final la = await linearAcceleration(extra: extra);
       readings['linear_acceleration'] = la;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow
     }
 
     try {
-      double comp = await compassHeading(extra: extra);
+      final comp = await compassHeading(extra: extra);
       readings['compass'] = comp;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow
     }
 
     try {
-      Orientation orient = await orientation(extra: extra);
+      final orient = await orientation(extra: extra);
       readings['orientation'] = orient;
     } catch (exception) {
       // TODO: Check if the exception is of a specific type and ignore or rethrow

--- a/lib/src/components/sensor/service.dart
+++ b/lib/src/components/sensor/service.dart
@@ -11,7 +11,7 @@ class SensorService extends SensorServiceBase {
 
   SensorService(this._manager);
 
-  Sensor _sensorFromManager(String name) {
+  Sensor _fromManager(String name) {
     try {
       return _manager.getResource(Sensor.getResourceName(name));
     } catch (e) {
@@ -21,15 +21,15 @@ class SensorService extends SensorServiceBase {
 
   @override
   Future<GetReadingsResponse> getReadings(ServiceCall call, GetReadingsRequest request) async {
-    Sensor sensor = _sensorFromManager(request.name);
-    var result = await sensor.readings(extra: request.extra.toMap());
+    final sensor = _fromManager(request.name);
+    final result = await sensor.readings(extra: request.extra.toMap());
     return GetReadingsResponse(readings: result.toStruct().fields);
   }
 
   @override
   Future<DoCommandResponse> doCommand(ServiceCall call, DoCommandRequest request) async {
-    Sensor sensor = _sensorFromManager(request.name);
-    var result = await sensor.doCommand(request.command.toMap());
+    final sensor = _fromManager(request.name);
+    final result = await sensor.doCommand(request.command.toMap());
     return DoCommandResponse(result: result.toStruct());
   }
 }

--- a/lib/src/components/servo/service.dart
+++ b/lib/src/components/servo/service.dart
@@ -21,35 +21,35 @@ class ServoService extends ServoServiceBase {
 
   @override
   Future<MoveResponse> move(ServiceCall call, MoveRequest request) async {
-    final Servo servo = _fromManager(request.name);
+    final servo = _fromManager(request.name);
     await servo.move(request.angleDeg, extra: request.extra.toMap());
     return MoveResponse();
   }
 
   @override
   Future<DoCommandResponse> doCommand(ServiceCall call, DoCommandRequest request) async {
-    final Servo servo = _fromManager(request.name);
+    final servo = _fromManager(request.name);
     final result = await servo.doCommand(request.command.toMap());
     return DoCommandResponse(result: result.toStruct());
   }
 
   @override
   Future<GetPositionResponse> getPosition(ServiceCall call, GetPositionRequest request) async {
-    final Servo servo = _fromManager(request.name);
-    final int positionDeg = await servo.position(extra: request.extra.toMap());
+    final servo = _fromManager(request.name);
+    final positionDeg = await servo.position(extra: request.extra.toMap());
     return GetPositionResponse(positionDeg: positionDeg);
   }
 
   @override
   Future<IsMovingResponse> isMoving(ServiceCall call, IsMovingRequest request) async {
-    final Servo servo = _fromManager(request.name);
-    final bool isMoving = await servo.isMoving();
+    final servo = _fromManager(request.name);
+    final isMoving = await servo.isMoving();
     return IsMovingResponse(isMoving: isMoving);
   }
 
   @override
   Future<StopResponse> stop(ServiceCall call, StopRequest request) async {
-    final Servo servo = _fromManager(request.name);
+    final servo = _fromManager(request.name);
     await servo.stop(extra: request.extra.toMap());
     return StopResponse();
   }

--- a/lib/src/components/servo/service.dart
+++ b/lib/src/components/servo/service.dart
@@ -29,7 +29,7 @@ class ServoService extends ServoServiceBase {
   @override
   Future<DoCommandResponse> doCommand(ServiceCall call, DoCommandRequest request) async {
     final Servo servo = _fromManager(request.name);
-    var result = await servo.doCommand(request.command.toMap());
+    final result = await servo.doCommand(request.command.toMap());
     return DoCommandResponse(result: result.toStruct());
   }
 

--- a/lib/src/domain/movement/service/viam_movement_service.dart
+++ b/lib/src/domain/movement/service/viam_movement_service.dart
@@ -11,11 +11,11 @@ class ViamMovementService {
   );
 
   Future<ViamPosition> getPositionData(ViamResourceName name) async {
-    var locationRequest = GetPositionRequest();
+    final locationRequest = GetPositionRequest();
     final resourceName = name.toDto();
     locationRequest.name = resourceName.name;
 
-    var response = await _movementSensorServiceClient.getPosition(locationRequest);
+    final response = await _movementSensorServiceClient.getPosition(locationRequest);
 
     return response.toDomain();
   }

--- a/lib/src/domain/sensor/service/viam_sensor_service.dart
+++ b/lib/src/domain/sensor/service/viam_sensor_service.dart
@@ -12,7 +12,7 @@ class ViamSensorService {
     List<ViamResourceName> resourceNames,
     String sensorRequestName,
   ) async {
-    var sensorRequest = GetReadingsRequest();
+    final sensorRequest = GetReadingsRequest();
 
     sensorRequest.name = sensorRequestName;
 
@@ -27,7 +27,7 @@ class ViamSensorService {
 
     sensorRequest.sensorNames.addAll([sensorNames]);
 
-    var response = await _sensorsServiceClient.getReadings(sensorRequest);
+    final response = await _sensorsServiceClient.getReadings(sensorRequest);
 
     return response.readings.map<ViamSensorReadings>((dto) => dto.toDomain()).toList(growable: false);
   }

--- a/lib/src/media/image.dart
+++ b/lib/src/media/image.dart
@@ -125,7 +125,7 @@ class _ViamRGBADecoder extends img.Decoder {
       height: info.height,
       numChannels: 4,
     );
-    int bitsPerPixel = 32;
+    const int bitsPerPixel = 32;
     final rowStride = ((_info.width * bitsPerPixel + 31) ~/ 32) * 4;
 
     for (var y = image.height - 1; y >= 0; --y) {
@@ -135,10 +135,10 @@ class _ViamRGBADecoder extends img.Decoder {
       var x = 0;
       final p = image.getPixel(0, line);
       while (x < w) {
-        num r = row.readByte();
-        num g = row.readByte();
-        num b = row.readByte();
-        num a = row.readByte();
+        final num r = row.readByte();
+        final num g = row.readByte();
+        final num b = row.readByte();
+        final num a = row.readByte();
         p.setRgba(r, g, b, a);
         p.moveNext();
         x++;

--- a/lib/src/resource/manager.dart
+++ b/lib/src/resource/manager.dart
@@ -12,7 +12,7 @@ class ResourceManager {
     }
     final shortName = name.name.split(':').last;
     if (!(_shortToLongName[shortName]?.contains(name) ?? true)) {
-      var names = _shortToLongName[shortName] ?? [];
+      final names = _shortToLongName[shortName] ?? [];
       names.add(name);
       _shortToLongName[shortName] = names;
     }

--- a/lib/src/robot/client.dart
+++ b/lib/src/robot/client.dart
@@ -31,7 +31,7 @@ class RobotClient {
   RobotClient._();
 
   static Future<RobotClient> atAddress(String url, RobotClientOptions options) async {
-    var client = RobotClient._();
+    final client = RobotClient._();
     client.channel = await dial(url, options.dialOptions);
     client._client = RobotServiceClient(client.channel);
     await client.refresh();
@@ -39,7 +39,7 @@ class RobotClient {
   }
 
   static Future<RobotClient> withViam(Viam viam) async {
-    var client = RobotClient._();
+    final client = RobotClient._();
     client.channel = viam.channel;
     client._client = RobotServiceClient(client.channel);
     await client.refresh();
@@ -47,7 +47,7 @@ class RobotClient {
   }
 
   Future<void> refresh() async {
-    ResourceNamesResponse response = await _client.resourceNames(ResourceNamesRequest());
+    final ResourceNamesResponse response = await _client.resourceNames(ResourceNamesRequest());
     if (response.resources == resourceNames) {
       return;
     }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -57,10 +57,10 @@ extension ListValueUtils<T extends ValueType> on List<T> {
 
 extension MapStructUtils on Map<String, dynamic> {
   Struct toStruct() {
-    Map<String, Value> result = {};
+    final Map<String, Value> result = {};
     for (var entry in entries) {
       try {
-        var value = entry.value;
+        final value = entry.value;
         if (value is num) {
           result[entry.key] = Value(numberValue: value.toDouble());
         } else if (value is String) {

--- a/test/unit_test/components/base_test.dart
+++ b/test/unit_test/components/base_test.dart
@@ -176,7 +176,7 @@ void main() {
 
     setUp(() async {
       base = FakeBase(name);
-      ResourceManager manager = ResourceManager();
+      final manager = ResourceManager();
       manager.register(Base.getResourceName(name), base);
       service = BaseService(manager);
       channel = ClientChannel('localhost', port: 50051, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
@@ -273,11 +273,10 @@ void main() {
       });
 
       test('doCommand', () async {
-        final cmd = {'foo': 'bar'};
-
+        final Map<String, String> cmd = {'foo': 'bar'};
         final client = BaseServiceClient(channel);
         final resp = await client.doCommand(DoCommandRequest(name: name, command: cmd.toStruct()));
-        expect(resp.result.toMap()['command'], cmd);
+        expect(resp.result.toMap(), {'command': cmd});
       });
 
       test('extra', () async {

--- a/test/unit_test/components/servo_test.dart
+++ b/test/unit_test/components/servo_test.dart
@@ -102,19 +102,19 @@ void main() {
     late ServoService service;
     late Server server;
     late String name;
-    const int testPosition = 42;
+    const testPosition = 42;
 
     setUp(() async {
       name = 'servo';
       servo = FakeServo(name);
-      ResourceManager manager = ResourceManager();
+      final manager = ResourceManager();
       manager.register(Servo.getResourceName(name), servo);
 
       service = ServoService(manager);
 
       channel = ClientChannel(
         'localhost',
-        port: 50051,
+        port: 50050,
         options: ChannelOptions(
           credentials: const ChannelCredentials.insecure(),
           codecRegistry: CodecRegistry(codecs: const [GzipCodec(), IdentityCodec()]),
@@ -126,7 +126,7 @@ void main() {
         const <Interceptor>[],
         CodecRegistry(codecs: const [GzipCodec(), IdentityCodec()]),
       );
-      await server.serve(port: 50051);
+      await server.serve(port: 50050);
     });
 
     tearDown(() async {
@@ -135,33 +135,33 @@ void main() {
     });
     group('Servo Service Tests', () {
       test('move should move the servo to new given position', () async {
-        ServoServiceClient client = ServoServiceClient(channel);
+        final client = ServoServiceClient(channel);
         await client.move(MoveRequest(name: name, angleDeg: testPosition));
         expect(servo.angle, testPosition);
       });
 
       test('getPosition should return the servos angle', () async {
-        ServoServiceClient client = ServoServiceClient(channel);
+        final client = ServoServiceClient(channel);
         final response = await client.getPosition(GetPositionRequest(name: name));
         expect(response.positionDeg, servo.angle);
       });
 
       test('stop should stop the servo', () async {
-        ServoServiceClient client = ServoServiceClient(channel);
+        final client = ServoServiceClient(channel);
         servo.isStopped = false;
         await client.stop(StopRequest(name: name));
         expect(servo.isStopped, true);
       });
 
       test('isMoving should return if the servo is moving', () async {
-        ServoServiceClient client = ServoServiceClient(channel);
-        IsMovingResponse response = await client.isMoving(IsMovingRequest(name: name));
+        final client = ServoServiceClient(channel);
+        final response = await client.isMoving(IsMovingRequest(name: name));
         expect(response.isMoving, !servo.isStopped);
       });
 
       test('doCommand', () async {
-        ServoServiceClient client = ServoServiceClient(channel);
-        final Map<String, String> command = {'command': 'args'};
+        final client = ServoServiceClient(channel);
+        Map<String, String> command = {'command': 'args'};
         final request = DoCommandRequest(name: name, command: command.toStruct());
         final response = await client.doCommand(request);
         expect(response.result.toMap(), {'command': command});
@@ -169,32 +169,32 @@ void main() {
     });
     group('Servo Client Tests', () {
       test('move should move the servo to new given position', () async {
-        ServoClient client = ServoClient(servo.name, channel);
+        final client = ServoClient(servo.name, channel);
         await client.move(testPosition);
         expect(servo.angle, testPosition);
       });
 
       test('getPosition should return the servos angle', () async {
-        ServoClient client = ServoClient(servo.name, channel);
+        final client = ServoClient(servo.name, channel);
         final response = await client.position();
         expect(response, servo.angle);
       });
 
       test('stop should stop the servo', () async {
-        ServoClient client = ServoClient(servo.name, channel);
+        final client = ServoClient(servo.name, channel);
         servo.isStopped = false;
         await client.stop();
         expect(servo.isStopped, true);
       });
 
       test('isMoving should return if the servo is moving', () async {
-        ServoClient client = ServoClient(servo.name, channel);
-        bool response = await client.isMoving();
+        final client = ServoClient(servo.name, channel);
+        final response = await client.isMoving();
         expect(response, !servo.isStopped);
       });
 
       test('doCommand', () async {
-        ServoClient client = ServoClient(servo.name, channel);
+        final client = ServoClient(servo.name, channel);
         final Map<String, String> command = {'command': 'args'};
         final response = await client.doCommand(command);
         expect(response, {'command': command});

--- a/test/unit_test/components/servo_test.dart
+++ b/test/unit_test/components/servo_test.dart
@@ -50,7 +50,7 @@ void main() {
   group('FakeServo Tests', () {
     late FakeServo servo;
     late String name;
-    const int testPosition = 42;
+    const testPosition = 42;
     setUp(() {
       name = 'servo';
       servo = FakeServo(name);


### PR DESCRIPTION
added lint rule prefer_final_locals

> Declaring variables as final when possible is a good practice because it helps avoid accidental reassignments and allows the compiler to do optimizations.

https://dart-lang.github.io/linter/lints/prefer_final_locals.html

Also removed some unnecessary type annotations - https://dart.dev/effective-dart/design#types

> Don’t annotate locals and generic invocations unless you need to.