### PR TITLE
RSDK-3127 - update named parameters in movement sensor

### DIFF
--- a/lib/src/components/movement_sensor/service.dart
+++ b/lib/src/components/movement_sensor/service.dart
@@ -29,8 +29,8 @@ class MovementSensorService extends MovementSensorServiceBase {
   @override
   Future<GetAccuracyResponse> getAccuracy(ServiceCall call, GetAccuracyRequest request) async {
     final movementSensor = _fromManager(request.name);
-    final accuracyMm = await movementSensor.accuracy(extra: request.extra.toMap());
-    return GetAccuracyResponse(accuracyMm: accuracyMm);
+    final accuracy = await movementSensor.accuracy(extra: request.extra.toMap());
+    return GetAccuracyResponse(accuracy: accuracy);
   }
 
   @override
@@ -72,7 +72,7 @@ class MovementSensorService extends MovementSensorServiceBase {
   Future<GetPositionResponse> getPosition(ServiceCall call, GetPositionRequest request) async {
     final movementSensor = _fromManager(request.name);
     final position = await movementSensor.position(extra: request.extra.toMap());
-    return GetPositionResponse(coordinate: position.coordinates, altitudeMm: position.altitude);
+    return GetPositionResponse(coordinate: position.coordinates, altitudeM: position.altitude);
   }
 
   @override


### PR DESCRIPTION
Quick fix to update the names of parameters in the movement sensor

caught by https://github.com/viamrobotics/viam-flutter-sdk/actions/runs/5135209703/jobs/9240317699

the names changed in the most recent protos update and I didn't catch it before merging. 