### PR TITLE
[RSDK-3762] Add stream manager

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
             channel: 'stable'
-            
+
       - run: flutter --version
       - run: flutter pub get
       - run: flutter pub get --directory=example/viam_example_app

--- a/example/viam_example_app/lib/screens/stream.dart
+++ b/example/viam_example_app/lib/screens/stream.dart
@@ -126,7 +126,7 @@ class _StreamScreenState extends State<StreamScreen> {
                   )
                 : const Text(''),
             const SizedBox(height: 16),
-            PlatformElevatedButton(child: const Text('Start stream'), onPressed: !_loading ? () => _startStream() : null),
+            PlatformElevatedButton(onPressed: !_loading ? () => _startStream() : null, child: const Text('Start stream')),
             const SizedBox(height: 16),
             _imgLoaded ? Image.memory(Uint8List.view(imageBytes!.buffer), scale: 3) : const Text(''),
             const SizedBox(height: 16),

--- a/example/viam_example_app/lib/screens/stream.dart
+++ b/example/viam_example_app/lib/screens/stream.dart
@@ -32,13 +32,6 @@ class _StreamScreenState extends State<StreamScreen> {
   ByteData? imageBytes;
   bool _imgLoaded = false;
 
-  @override
-  void initState() {
-    _ready = false;
-    _loading = false;
-    super.initState();
-  }
-
   void _getImage() {
     setState(() {
       _imgLoaded = false;

--- a/lib/src/media/stream/client.dart
+++ b/lib/src/media/stream/client.dart
@@ -5,51 +5,112 @@ import 'package:flutter_webrtc/flutter_webrtc.dart';
 import '../../domain/web_rtc/web_rtc_client/web_rtc_client.dart';
 import '../../gen/proto/stream/v1/stream.pbgrpc.dart';
 
-class StreamClient {
+class StreamManager {
+  final Map<String, MediaStream> _streams = {};
+  final Map<String, StreamClient> _clients = {};
   final WebRtcClientChannel _channel;
   final StreamServiceClient _client;
-  // ignore: close_sinks
-  final StreamController<MediaStream> _streamController = StreamController<MediaStream>.broadcast();
-  MediaStream? _stream;
   StreamSubscription? _errorHandler;
 
-  StreamClient(this._channel) : _client = StreamServiceClient(_channel) {
+  static final Finalizer<StreamSubscription?> _finalizer = Finalizer((p0) {
+    p0?.cancel();
+  });
+
+  StreamManager(this._channel) : _client = StreamServiceClient(_channel) {
+    _finalizer.attach(this, _errorHandler);
     _channel.rtcPeerConnection.onAddStream = (MediaStream stream) {
-      _stream = stream;
-      _streamController.add(stream);
+      addStream(stream);
     };
 
     _channel.rtcPeerConnection.onConnectionState = (state) {
       if (state == RTCPeerConnectionState.RTCPeerConnectionStateFailed ||
           state == RTCPeerConnectionState.RTCPeerConnectionStateDisconnected) {
         _errorHandler = Stream.periodic(const Duration(seconds: 1)).listen((_) {
-          _streamController.addError(Exception('PeerConnection error'));
+          for (final client in _clients.values) {
+            client._streamController.addError(Exception('PeerConnection error'));
+          }
         });
       }
     };
   }
 
-  String _getValidSDPTrackName(String name) {
+  void addStream(MediaStream stream) {
+    _streams[stream.id] = stream;
+    if (_clients.containsKey(stream.id)) {
+      _clients[stream.id]!._internalStreamController.add(stream);
+    }
+  }
+
+  String getValidSDPTrackName(String name) {
     return name.replaceAll(':', '+');
   }
 
-  Stream<MediaStream> getStream(String name) {
-    if (_stream == null) {
-      final future = add(name);
-      future.onError((error, stackTrace) => _streamController.addError(error ?? Exception('Could not add stream named $name')));
+  StreamClient getStreamClient(String name) {
+    final sanitizedName = getValidSDPTrackName(name);
+    if (_clients.containsKey(sanitizedName)) {
+      return _clients[sanitizedName]!;
+    }
+    final client = StreamClient(name, remove);
+    _clients[sanitizedName] = client;
+
+    if (_streams.containsKey(sanitizedName)) {
+      Future.delayed(const Duration(milliseconds: 100), () {
+        _clients[sanitizedName]!._internalStreamController.add(_streams[sanitizedName]!);
+      });
     } else {
-      _streamController.add(_stream!);
+      final fut = add(sanitizedName);
+      fut.onError((error, stackTrace) => client._streamController.addError(error ?? Exception('Could not add stream named $name')));
+    }
+    return client;
+  }
+
+  Future<void> add(String name) async {
+    await _client.addStream(AddStreamRequest(name: name));
+  }
+
+  Future<void> remove(String name) async {
+    final sanitizedName = getValidSDPTrackName(name);
+    if (_streams.containsKey(sanitizedName)) {
+      final stream = _streams.remove(sanitizedName)!;
+      await stream.dispose();
+      await _client.removeStream(RemoveStreamRequest(name: sanitizedName));
+    }
+    if (_clients.containsKey(sanitizedName)) {
+      _clients.remove(sanitizedName)!;
+    }
+  }
+}
+
+class StreamClient {
+  final String name;
+  final Future<void> Function(String name) _close;
+  MediaStream? _stream;
+
+  // ignore: close_sinks
+  final StreamController<MediaStream> _internalStreamController = StreamController<MediaStream>.broadcast();
+
+  // ignore: close_sinks
+  final StreamController<MediaStream> _streamController = StreamController<MediaStream>.broadcast();
+
+  StreamClient(this.name, this._close) {
+    _internalStreamController.stream.listen((event) {
+      _stream = event;
+      _streamController.add(event);
+    });
+  }
+
+  Stream<MediaStream> getStream() {
+    if (_stream != null) {
+      Future.delayed(const Duration(milliseconds: 100), () {
+        _streamController.add(_stream!);
+      });
     }
     return _streamController.stream;
   }
 
-  Future<void> add(String name) async {
-    await _client.addStream(AddStreamRequest(name: _getValidSDPTrackName(name)));
-  }
-
-  Future<void> remove(String name) async {
-    await _client.removeStream(RemoveStreamRequest(name: _getValidSDPTrackName(name)));
-    _stream = null;
-    await _errorHandler?.cancel();
+  Future<void> closeStream() async {
+    await _streamController.close();
+    await _internalStreamController.close();
+    await _close(name);
   }
 }

--- a/lib/src/robot/client.dart
+++ b/lib/src/robot/client.dart
@@ -34,7 +34,7 @@ class RobotClient {
   late RobotServiceClient _client;
   List<ResourceName> resourceNames = [];
   ResourceManager _manager = ResourceManager();
-  final Map<String, StreamClient> _streams = {};
+  late final StreamManager _streamManager;
 
   RobotClient._();
 
@@ -43,6 +43,7 @@ class RobotClient {
     final client = RobotClient._();
     client.channel = await dial(url, options.dialOptions);
     client._client = RobotServiceClient(client.channel);
+    client._streamManager = StreamManager(client.channel as WebRtcClientChannel);
     await client.refresh();
     return client;
   }
@@ -89,9 +90,6 @@ class RobotClient {
 
   /// Get a WebRTC stream client with the given name
   StreamClient getStream(String name) {
-    if (!_streams.containsKey(name)) {
-      _streams[name] = StreamClient(channel as WebRtcClientChannel);
-    }
-    return _streams[name]!;
+    return _streamManager.getStreamClient(name);
   }
 }

--- a/lib/src/widgets/widgets.dart
+++ b/lib/src/widgets/widgets.dart
@@ -29,14 +29,14 @@ class _CameraStreamViewState extends State<CameraStreamView> {
   void deactivate() {
     super.deactivate();
     _renderer.dispose();
-    widget.streamClient.remove(widget.camera.name);
+    widget.streamClient.closeStream();
     _streamSub.cancel();
   }
 
   Future<void> _startStream() async {
     _renderer = RTCVideoRenderer();
     await _renderer.initialize();
-    final stream = widget.streamClient.getStream(widget.camera.name);
+    final stream = widget.streamClient.getStream();
     _streamSub = stream.listen((event) {
       _renderer.srcObject = event;
       setState(() {});

--- a/lib/viam_sdk.dart
+++ b/lib/viam_sdk.dart
@@ -52,7 +52,7 @@ export 'src/gen/common/v1/common.pb.dart'
 
 /// Media & Streams
 export 'src/media/image.dart';
-export 'src/media/stream/client.dart';
+export 'src/media/stream/client.dart' hide StreamManager;
 
 /// Robot, Resource, and Registry
 export 'src/resource/base.dart';


### PR DESCRIPTION
Because the webrtc peer is shared across the entire app, when each `StreamClient` would call `_channel.rtcPeerConnection.onAddStream`, it would overwrite any existing `onAddStream` definition. This made it such that whatever `StreamClient` was initialized last would be the one to control the peer connection. 

So I created a manager which will be the only object that manages all `onAddStream` events. It then saves those streams and can create/return a `StreamClient` when requested. 