### PR TITLE
RSDK-3192 - Add robot reconnection logic

### DIFF
--- a/lib/src/components/arm/client.dart
+++ b/lib/src/components/arm/client.dart
@@ -2,57 +2,61 @@ import 'package:grpc/grpc_connection_interface.dart';
 
 import '../../gen/common/v1/common.pb.dart';
 import '../../gen/component/arm/v1/arm.pbgrpc.dart';
+import '../../resource/base.dart';
 import '../../utils.dart';
 import 'arm.dart';
 
 /// gRPC client for an [Arm] component.
 ///
 /// Used to communicate with an existing [Arm] implementation over gRPC.
-class ArmClient extends Arm {
-  final ClientChannelBase _channel;
-  final ArmServiceClient _client;
-
+class ArmClient extends Arm implements ResourceRPCClient {
   @override
   String name;
 
-  ArmClient(this.name, this._channel) : _client = ArmServiceClient(_channel);
+  @override
+  ClientChannelBase channel;
+
+  @override
+  ArmServiceClient get client => ArmServiceClient(channel);
+
+  ArmClient(this.name, this.channel);
 
   @override
   Future<Pose> endPosition({Map<String, dynamic>? extra}) async {
-    final response = await _client.getEndPosition(GetEndPositionRequest(name: name, extra: extra?.toStruct()));
+    final response = await client.getEndPosition(GetEndPositionRequest(name: name, extra: extra?.toStruct()));
     return response.pose;
   }
 
   @override
   Future<bool> isMoving() async {
-    final response = await _client.isMoving(IsMovingRequest(name: name));
+    final response = await client.isMoving(IsMovingRequest(name: name));
     return response.isMoving;
   }
 
   @override
   Future<void> moveToJointPositions(JointPositions positions, {Map<String, dynamic>? extra}) async {
-    await _client.moveToJointPositions(MoveToJointPositionsRequest(name: name, positions: positions, extra: extra?.toStruct()));
+    await client.moveToJointPositions(MoveToJointPositionsRequest(name: name, positions: positions, extra: extra?.toStruct()));
   }
 
   @override
   Future<void> moveToPosition(Pose pose, {Map<String, dynamic>? extra}) async {
-    await _client.moveToPosition(MoveToPositionRequest(name: name, to: pose, extra: extra?.toStruct()));
+    await client.moveToPosition(MoveToPositionRequest(name: name, to: pose, extra: extra?.toStruct()));
   }
 
   @override
   Future<JointPositions> jointPositions({Map<String, dynamic>? extra}) async {
-    final response = await _client.getJointPositions(GetJointPositionsRequest(name: name, extra: extra?.toStruct()));
+    final response = await client.getJointPositions(GetJointPositionsRequest(name: name, extra: extra?.toStruct()));
     return response.positions;
   }
 
   @override
   Future<void> stop({Map<String, dynamic>? extra}) async {
-    await _client.stop(StopRequest(name: name, extra: extra?.toStruct()));
+    await client.stop(StopRequest(name: name, extra: extra?.toStruct()));
   }
 
   @override
   Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) async {
-    final response = await _client.doCommand(DoCommandRequest(name: name, command: command.toStruct()));
+    final response = await client.doCommand(DoCommandRequest(name: name, command: command.toStruct()));
     return response.result.toMap();
   }
 }

--- a/lib/src/components/base/client.dart
+++ b/lib/src/components/base/client.dart
@@ -3,53 +3,57 @@ import 'package:grpc/grpc_connection_interface.dart';
 
 import '../../gen/common/v1/common.pb.dart';
 import '../../gen/component/base/v1/base.pbgrpc.dart';
+import '../../resource/base.dart';
 import '../../utils.dart';
 import 'base.dart';
 
 /// gRPC client for the [Base] component.
-class BaseClient extends Base {
-  final ClientChannelBase _channel;
-  final BaseServiceClient _client;
-
+class BaseClient extends Base implements ResourceRPCClient {
   @override
   String name;
 
-  BaseClient(this.name, this._channel) : _client = BaseServiceClient(_channel);
+  @override
+  ClientChannelBase channel;
+
+  @override
+  BaseServiceClient get client => BaseServiceClient(channel);
+
+  BaseClient(this.name, this.channel);
 
   @override
   Future<bool> isMoving() async {
-    final response = await _client.isMoving(IsMovingRequest(name: name));
+    final response = await client.isMoving(IsMovingRequest(name: name));
     return response.isMoving;
   }
 
   @override
   Future<void> moveStraight(int distance, double velocity, {Map<String, dynamic>? extra}) async {
-    await _client.moveStraight(MoveStraightRequest(name: name, distanceMm: Int64(distance), mmPerSec: velocity, extra: extra?.toStruct()));
+    await client.moveStraight(MoveStraightRequest(name: name, distanceMm: Int64(distance), mmPerSec: velocity, extra: extra?.toStruct()));
   }
 
   @override
   Future<void> setPower(Vector3 linear, Vector3 angular, {Map<String, dynamic>? extra}) async {
-    await _client.setPower(SetPowerRequest(name: name, linear: linear, angular: angular, extra: extra?.toStruct()));
+    await client.setPower(SetPowerRequest(name: name, linear: linear, angular: angular, extra: extra?.toStruct()));
   }
 
   @override
   Future<void> setVelocity(Vector3 linear, Vector3 angular, {Map<String, dynamic>? extra}) async {
-    await _client.setVelocity(SetVelocityRequest(name: name, linear: linear, angular: angular, extra: extra?.toStruct()));
+    await client.setVelocity(SetVelocityRequest(name: name, linear: linear, angular: angular, extra: extra?.toStruct()));
   }
 
   @override
   Future<void> spin(double angle, double velocity, {Map<String, dynamic>? extra}) async {
-    await _client.spin(SpinRequest(name: name, angleDeg: angle, degsPerSec: velocity, extra: extra?.toStruct()));
+    await client.spin(SpinRequest(name: name, angleDeg: angle, degsPerSec: velocity, extra: extra?.toStruct()));
   }
 
   @override
   Future<void> stop({Map<String, dynamic>? extra}) async {
-    await _client.stop(StopRequest(name: name, extra: extra?.toStruct()));
+    await client.stop(StopRequest(name: name, extra: extra?.toStruct()));
   }
 
   @override
   Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) async {
-    final response = await _client.doCommand(DoCommandRequest(name: name, command: command.toStruct()));
+    final response = await client.doCommand(DoCommandRequest(name: name, command: command.toStruct()));
     return response.result.toMap();
   }
 }

--- a/lib/src/components/board/client.dart
+++ b/lib/src/components/board/client.dart
@@ -4,81 +4,85 @@ import 'package:grpc/grpc_connection_interface.dart';
 import '../../gen/common/v1/common.pb.dart' as common;
 import '../../gen/component/board/v1/board.pbgrpc.dart';
 import '../../gen/google/protobuf/duration.pb.dart' as grpc_duration;
+import '../../resource/base.dart';
 import '../../utils.dart';
 import 'board.dart';
 
 /// gRPC client for the [Board] component.
-class BoardClient extends Board {
-  final ClientChannelBase _channel;
-  final BoardServiceClient _client;
-
+class BoardClient extends Board implements ResourceRPCClient {
   @override
   String name;
 
-  BoardClient(this.name, this._channel) : _client = BoardServiceClient(_channel);
+  @override
+  ClientChannelBase channel;
+
+  @override
+  BoardServiceClient get client => BoardServiceClient(channel);
+
+  BoardClient(this.name, this.channel);
 
   @override
   Future<Map<String, dynamic>> doCommand(Map<String, dynamic>? command) async {
-    final response = await _client.doCommand(common.DoCommandRequest(name: name, command: command?.toStruct()));
+    final response = await client.doCommand(common.DoCommandRequest(name: name, command: command?.toStruct()));
     return response.result.toMap();
   }
 
   @override
   Future<BoardStatus> status({Map<String, dynamic>? extra}) async {
-    final response = await _client.status(StatusRequest(name: name, extra: extra?.toStruct()));
+    final response = await client.status(StatusRequest(name: name, extra: extra?.toStruct()));
     return BoardStatus.fromProto(response.status);
   }
 
   @override
   Future<void> setGpioState(String pin, bool high, {Map<String, dynamic>? extra}) async {
-    await _client.setGPIO(SetGPIORequest(name: name, pin: pin, high: high, extra: extra?.toStruct()));
+    await client.setGPIO(SetGPIORequest(name: name, pin: pin, high: high, extra: extra?.toStruct()));
   }
 
   @override
   Future<bool> gpio(String pin, {Map<String, dynamic>? extra}) async {
-    final response = await _client.getGPIO(GetGPIORequest(name: name, pin: pin, extra: extra?.toStruct()));
+    final response = await client.getGPIO(GetGPIORequest(name: name, pin: pin, extra: extra?.toStruct()));
     return response.high;
   }
 
   @override
   Future<double> pwm(String pin, {Map<String, dynamic>? extra}) async {
-    final response = await _client.pWM(PWMRequest(name: name, pin: pin, extra: extra?.toStruct()));
+    final response = await client.pWM(PWMRequest(name: name, pin: pin, extra: extra?.toStruct()));
     return response.dutyCyclePct;
   }
 
   @override
   Future<void> setPwm(String pin, double dutyCyclePct, {Map<String, dynamic>? extra}) async {
-    await _client.setPWM(SetPWMRequest(name: name, pin: pin, dutyCyclePct: dutyCyclePct, extra: extra?.toStruct()));
+    await client.setPWM(SetPWMRequest(name: name, pin: pin, dutyCyclePct: dutyCyclePct, extra: extra?.toStruct()));
   }
 
   @override
   Future<int> pwmFrequency(String pin, {Map<String, dynamic>? extra}) async {
-    final response = await _client.pWMFrequency(PWMFrequencyRequest(name: name, pin: pin, extra: extra?.toStruct()));
+    final response = await client.pWMFrequency(PWMFrequencyRequest(name: name, pin: pin, extra: extra?.toStruct()));
     return response.frequencyHz.toInt();
   }
 
   @override
   Future<void> setPwmFrequency(String pin, int frequencyHz, {Map<String, dynamic>? extra}) async {
-    await _client.setPWMFrequency(SetPWMFrequencyRequest(name: name, pin: pin, frequencyHz: Int64(frequencyHz), extra: extra?.toStruct()));
+    await client.setPWMFrequency(SetPWMFrequencyRequest(name: name, pin: pin, frequencyHz: Int64(frequencyHz), extra: extra?.toStruct()));
   }
 
   @override
   Future<int> analogReaderValue(String analogReaderName, {Map<String, dynamic>? extra}) async {
-    final response = await _client
+    final response = await client
         .readAnalogReader(ReadAnalogReaderRequest(boardName: name, analogReaderName: analogReaderName, extra: extra?.toStruct()));
     return response.value;
   }
 
   @override
   Future<int> digitalInterruptValue(String digitalInterruptName, {Map<String, dynamic>? extra}) async {
-    final response = await _client.getDigitalInterruptValue(
+    final response = await client.getDigitalInterruptValue(
         GetDigitalInterruptValueRequest(boardName: name, digitalInterruptName: digitalInterruptName, extra: extra?.toStruct()));
     return response.value.toInt();
   }
 
   @override
   Future<void> setPowerMode(PowerMode powerMode, int seconds, int nanos, {Map<String, dynamic>? extra}) async {
-    await _client.setPowerMode(SetPowerModeRequest(
+    await client.setPowerMode(SetPowerModeRequest(
         name: name,
         powerMode: powerMode,
         duration: grpc_duration.Duration(seconds: Int64(seconds), nanos: nanos),

--- a/lib/src/components/camera/client.dart
+++ b/lib/src/components/camera/client.dart
@@ -3,23 +3,27 @@ import 'package:grpc/grpc_connection_interface.dart';
 import '../../gen/common/v1/common.pb.dart';
 import '../../gen/component/camera/v1/camera.pbgrpc.dart';
 import '../../media/image.dart';
+import '../../resource/base.dart';
 import '../../utils.dart';
 import 'camera.dart';
 
 /// gRPC client for the [Camera] component
-class CameraClient extends Camera {
-  final ClientChannelBase _channel;
-  final CameraServiceClient _client;
-
+class CameraClient extends Camera implements ResourceRPCClient {
   @override
   String name;
 
-  CameraClient(this.name, this._channel) : _client = CameraServiceClient(_channel);
+  @override
+  ClientChannelBase channel;
+
+  @override
+  CameraServiceClient get client => CameraServiceClient(channel);
+
+  CameraClient(this.name, this.channel);
 
   @override
   Future<ViamImage> image({MimeType? mimeType}) async {
     final request = GetImageRequest(name: name, mimeType: mimeType?.name);
-    final response = await _client.getImage(request);
+    final response = await client.getImage(request);
     final actualMimeType = MimeType.fromString(response.mimeType);
     return ViamImage(response.image, actualMimeType);
   }
@@ -27,7 +31,7 @@ class CameraClient extends Camera {
   @override
   Future<ViamImage> pointCloud() async {
     final request = GetPointCloudRequest(name: name, mimeType: MimeType.pcd.name);
-    final response = await _client.getPointCloud(request);
+    final response = await client.getPointCloud(request);
     final actualMimeType = MimeType.fromString(response.mimeType);
     return ViamImage(response.pointCloud, actualMimeType);
   }
@@ -35,13 +39,13 @@ class CameraClient extends Camera {
   @override
   Future<CameraProperties> properties() async {
     final request = GetPropertiesRequest(name: name);
-    final response = await _client.getProperties(request);
+    final response = await client.getProperties(request);
     return CameraProperties(response.supportsPcd, response.intrinsicParameters, response.distortionParameters);
   }
 
   @override
   Future<Map<String, dynamic>> doCommand(Map<String, dynamic>? command) async {
-    final response = await _client.doCommand(DoCommandRequest(name: name, command: command?.toStruct()));
+    final response = await client.doCommand(DoCommandRequest(name: name, command: command?.toStruct()));
     return response.result.toMap();
   }
 }

--- a/lib/src/components/gantry/client.dart
+++ b/lib/src/components/gantry/client.dart
@@ -2,56 +2,60 @@ import 'package:grpc/grpc_connection_interface.dart';
 
 import '../../gen/common/v1/common.pb.dart';
 import '../../gen/component/gantry/v1/gantry.pbgrpc.dart';
+import '../../resource/base.dart';
 import '../../utils.dart';
 import 'gantry.dart';
 
 /// gRPC client for the [Gantry] component.
-class GantryClient extends Gantry {
-  final ClientChannelBase _channel;
-  final GantryServiceClient _client;
-
+class GantryClient extends Gantry implements ResourceRPCClient {
   @override
   String name;
 
-  GantryClient(this.name, this._channel) : _client = GantryServiceClient(_channel);
+  @override
+  ClientChannelBase channel;
+
+  @override
+  GantryServiceClient get client => GantryServiceClient(channel);
+
+  GantryClient(this.name, this.channel);
 
   @override
   Future<bool> isMoving() async {
     final request = IsMovingRequest(name: name);
-    final response = await _client.isMoving(request);
+    final response = await client.isMoving(request);
     return response.isMoving;
   }
 
   @override
   Future<List<double>> lengths({Map<String, dynamic>? extra}) async {
     final request = GetLengthsRequest(name: name, extra: extra?.toStruct());
-    final response = await _client.getLengths(request);
+    final response = await client.getLengths(request);
     return response.lengthsMm;
   }
 
   @override
   Future<void> moveToPosition(List<double> positions, {Map<String, dynamic>? extra}) async {
     final request = MoveToPositionRequest(name: name, positionsMm: positions, extra: extra?.toStruct());
-    await _client.moveToPosition(request);
+    await client.moveToPosition(request);
   }
 
   @override
   Future<List<double>> position({Map<String, dynamic>? extra}) async {
     final request = GetPositionRequest(name: name, extra: extra?.toStruct());
-    final response = await _client.getPosition(request);
+    final response = await client.getPosition(request);
     return response.positionsMm;
   }
 
   @override
   Future<void> stop({Map<String, dynamic>? extra}) async {
     final request = StopRequest(name: name, extra: extra?.toStruct());
-    await _client.stop(request);
+    await client.stop(request);
   }
 
   @override
   Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) async {
     final request = DoCommandRequest(name: name, command: command.toStruct());
-    final response = await _client.doCommand(request);
+    final response = await client.doCommand(request);
     return response.result.toMap();
   }
 }

--- a/lib/src/components/motor/client.dart
+++ b/lib/src/components/motor/client.dart
@@ -2,71 +2,75 @@ import 'package:grpc/grpc_connection_interface.dart';
 
 import '../../gen/common/v1/common.pb.dart';
 import '../../gen/component/motor/v1/motor.pbgrpc.dart';
+import '../../resource/base.dart';
 import '../../utils.dart';
 import 'motor.dart';
 
 /// gRPC client for the [Motor] component.
-class MotorClient extends Motor {
-  final ClientChannelBase _channel;
-  final MotorServiceClient _client;
-
+class MotorClient extends Motor implements ResourceRPCClient {
   @override
   String name;
 
-  MotorClient(this.name, this._channel) : _client = MotorServiceClient(_channel);
+  @override
+  ClientChannelBase channel;
+
+  @override
+  MotorServiceClient get client => MotorServiceClient(channel);
+
+  MotorClient(this.name, this.channel);
 
   @override
   Future<void> setPower(double powerPct, {Map<String, dynamic>? extra}) async {
-    await _client.setPower(SetPowerRequest(name: name, powerPct: powerPct, extra: extra?.toStruct()));
+    await client.setPower(SetPowerRequest(name: name, powerPct: powerPct, extra: extra?.toStruct()));
   }
 
   @override
   Future<void> goFor(double rpm, double revolutions, {Map<String, dynamic>? extra}) async {
-    await _client.goFor(GoForRequest(name: name, rpm: rpm, revolutions: revolutions, extra: extra?.toStruct()));
+    await client.goFor(GoForRequest(name: name, rpm: rpm, revolutions: revolutions, extra: extra?.toStruct()));
   }
 
   @override
   Future<void> goTo(double rpm, double positionRevolutions, {Map<String, dynamic>? extra}) async {
-    await _client.goTo(GoToRequest(name: name, rpm: rpm, positionRevolutions: positionRevolutions, extra: extra?.toStruct()));
+    await client.goTo(GoToRequest(name: name, rpm: rpm, positionRevolutions: positionRevolutions, extra: extra?.toStruct()));
   }
 
   @override
   Future<void> resetZeroPosition(double offset, {Map<String, dynamic>? extra}) async {
-    await _client.resetZeroPosition(ResetZeroPositionRequest(name: name, offset: offset, extra: extra?.toStruct()));
+    await client.resetZeroPosition(ResetZeroPositionRequest(name: name, offset: offset, extra: extra?.toStruct()));
   }
 
   @override
   Future<double> position({Map<String, dynamic>? extra}) async {
-    final result = await _client.getPosition(GetPositionRequest(name: name, extra: extra?.toStruct()));
+    final result = await client.getPosition(GetPositionRequest(name: name, extra: extra?.toStruct()));
     return result.position;
   }
 
   @override
   Future<MotorProperties> properties({Map<String, dynamic>? extra}) async {
-    final result = await _client.getProperties(GetPropertiesRequest(name: name, extra: extra?.toStruct()));
+    final result = await client.getProperties(GetPropertiesRequest(name: name, extra: extra?.toStruct()));
     return MotorProperties.fromProto(result);
   }
 
   @override
   Future<void> stop({Map<String, dynamic>? extra}) async {
-    await _client.stop(StopRequest(name: name, extra: extra?.toStruct()));
+    await client.stop(StopRequest(name: name, extra: extra?.toStruct()));
   }
 
   @override
   Future<PowerState> powerState({Map<String, dynamic>? extra}) async {
-    final result = await _client.isPowered(IsPoweredRequest(name: name, extra: extra?.toStruct()));
+    final result = await client.isPowered(IsPoweredRequest(name: name, extra: extra?.toStruct()));
     return PowerState.fromProto(result);
   }
 
   @override
   Future<bool> isMoving({Map<String, dynamic>? extra}) async {
-    final result = await _client.isMoving(IsMovingRequest(name: name));
+    final result = await client.isMoving(IsMovingRequest(name: name));
     return result.isMoving;
   }
 
   @override
   Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) async {
-    final response = await _client.doCommand(DoCommandRequest(name: name, command: command.toStruct()));
+    final response = await client.doCommand(DoCommandRequest(name: name, command: command.toStruct()));
     return response.result.toMap();
   }
 }

--- a/lib/src/components/movement_sensor/client.dart
+++ b/lib/src/components/movement_sensor/client.dart
@@ -1,70 +1,77 @@
 import 'package:grpc/grpc_connection_interface.dart';
+import 'package:logger/logger.dart';
 
 import '../../gen/common/v1/common.pb.dart';
 import '../../gen/component/movementsensor/v1/movementsensor.pbgrpc.dart';
+import '../../resource/base.dart';
 import '../../utils.dart';
 import 'movement_sensor.dart';
 
-/// gRPC client for the [MovementSensor] component.
-class MovementSensorClient extends MovementSensor {
-  final ClientChannelBase _channel;
-  final MovementSensorServiceClient _client;
+Logger _logger = Logger();
 
+/// gRPC client for the [MovementSensor] component.
+class MovementSensorClient extends MovementSensor implements ResourceRPCClient {
   @override
   String name;
 
-  MovementSensorClient(this.name, this._channel) : _client = MovementSensorServiceClient(_channel);
+  @override
+  ClientChannelBase channel;
+
+  @override
+  MovementSensorServiceClient get client => MovementSensorServiceClient(channel);
+
+  MovementSensorClient(this.name, this.channel);
 
   @override
   Future<Position> position({Map<String, dynamic>? extra}) async {
-    final response = await _client.getPosition(GetPositionRequest(name: name, extra: extra?.toStruct()));
+    final response = await client.getPosition(GetPositionRequest(name: name, extra: extra?.toStruct()));
     return Position(response.coordinate, response.altitudeM);
   }
 
   @override
   Future<Vector3> linearVelocity({Map<String, dynamic>? extra}) async {
-    final response = await _client.getLinearVelocity(GetLinearVelocityRequest(name: name, extra: extra?.toStruct()));
+    final response = await client.getLinearVelocity(GetLinearVelocityRequest(name: name, extra: extra?.toStruct()));
     return response.linearVelocity;
   }
 
   @override
   Future<Vector3> angularVelocity({Map<String, dynamic>? extra}) async {
-    final response = await _client.getAngularVelocity(GetAngularVelocityRequest(name: name, extra: extra?.toStruct()));
+    final response = await client.getAngularVelocity(GetAngularVelocityRequest(name: name, extra: extra?.toStruct()));
     return response.angularVelocity;
   }
 
   @override
   Future<Vector3> linearAcceleration({Map<String, dynamic>? extra}) async {
-    final response = await _client.getLinearAcceleration(GetLinearAccelerationRequest(name: name, extra: extra?.toStruct()));
+    final response = await client.getLinearAcceleration(GetLinearAccelerationRequest(name: name, extra: extra?.toStruct()));
     return response.linearAcceleration;
   }
 
   @override
   Future<double> compassHeading({Map<String, dynamic>? extra}) async {
-    final response = await _client.getCompassHeading(GetCompassHeadingRequest(name: name, extra: extra?.toStruct()));
+    final response = await client.getCompassHeading(GetCompassHeadingRequest(name: name, extra: extra?.toStruct()));
     return response.value;
   }
 
   @override
   Future<Orientation> orientation({Map<String, dynamic>? extra}) async {
-    final response = await _client.getOrientation(GetOrientationRequest(name: name, extra: extra?.toStruct()));
+    final response = await client.getOrientation(GetOrientationRequest(name: name, extra: extra?.toStruct()));
     return response.orientation;
   }
 
   @override
   Future<Properties> properties({Map<String, dynamic>? extra}) async {
-    return await _client.getProperties(GetPropertiesRequest(name: name, extra: extra?.toStruct()));
+    return await client.getProperties(GetPropertiesRequest(name: name, extra: extra?.toStruct()));
   }
 
   @override
   Future<Map<String, double>> accuracy({Map<String, dynamic>? extra}) async {
-    final response = await _client.getAccuracy(GetAccuracyRequest(name: name, extra: extra?.toStruct()));
+    final response = await client.getAccuracy(GetAccuracyRequest(name: name, extra: extra?.toStruct()));
     return response.accuracy;
   }
 
   @override
   Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) async {
-    final response = await _client.doCommand(DoCommandRequest(name: name, command: command.toStruct()));
+    final response = await client.doCommand(DoCommandRequest(name: name, command: command.toStruct()));
     return response.result.toMap();
   }
 }

--- a/lib/src/components/sensor/client.dart
+++ b/lib/src/components/sensor/client.dart
@@ -2,28 +2,32 @@ import 'package:grpc/grpc_connection_interface.dart';
 
 import '../../gen/common/v1/common.pb.dart';
 import '../../gen/component/sensor/v1/sensor.pbgrpc.dart';
+import '../../resource/base.dart';
 import '../../utils.dart';
 import 'sensor.dart';
 
 /// gRPC client for the [Sensor] component.
-class SensorClient extends Sensor {
-  final ClientChannelBase _channel;
-  final SensorServiceClient _client;
-
+class SensorClient extends Sensor implements ResourceRPCClient {
   @override
   String name;
 
-  SensorClient(this.name, this._channel) : _client = SensorServiceClient(_channel);
+  @override
+  ClientChannelBase channel;
+
+  @override
+  SensorServiceClient get client => SensorServiceClient(channel);
+
+  SensorClient(this.name, this.channel);
 
   @override
   Future<Map<String, dynamic>> readings({Map<String, dynamic>? extra}) async {
-    final response = await _client.getReadings(GetReadingsRequest(name: name, extra: extra?.toStruct()));
+    final response = await client.getReadings(GetReadingsRequest(name: name, extra: extra?.toStruct()));
     return response.readings.map((key, value) => MapEntry(key, value.toPrimitive()));
   }
 
   @override
   Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) async {
-    final response = await _client.doCommand(DoCommandRequest(name: name, command: command.toStruct()));
+    final response = await client.doCommand(DoCommandRequest(name: name, command: command.toStruct()));
     return response.result.toMap();
   }
 }

--- a/lib/src/components/servo/client.dart
+++ b/lib/src/components/servo/client.dart
@@ -2,44 +2,48 @@ import 'package:grpc/grpc_connection_interface.dart';
 
 import '../../gen/common/v1/common.pb.dart';
 import '../../gen/component/servo/v1/servo.pbgrpc.dart';
+import '../../resource/base.dart';
 import '../../utils.dart';
 import 'servo.dart';
 
 /// gRPC client for the [Servo] component.
-class ServoClient extends Servo {
-  final ClientChannelBase _channel;
-  final ServoServiceClient _client;
-
+class ServoClient extends Servo implements ResourceRPCClient {
   @override
   String name;
 
-  ServoClient(this.name, this._channel) : _client = ServoServiceClient(_channel);
+  @override
+  ClientChannelBase channel;
+
+  @override
+  ServoServiceClient get client => ServoServiceClient(channel);
+
+  ServoClient(this.name, this.channel);
 
   @override
   Future<void> move(int angle, {Map<String, dynamic>? extra}) async {
-    await _client.move(MoveRequest(name: name, angleDeg: angle, extra: extra?.toStruct()));
+    await client.move(MoveRequest(name: name, angleDeg: angle, extra: extra?.toStruct()));
   }
 
   @override
   Future<int> position({Map<String, dynamic>? extra}) async {
-    final response = await _client.getPosition(GetPositionRequest(name: name, extra: extra?.toStruct()));
+    final response = await client.getPosition(GetPositionRequest(name: name, extra: extra?.toStruct()));
     return response.positionDeg;
   }
 
   @override
   Future<void> stop({Map<String, dynamic>? extra}) async {
-    await _client.stop(StopRequest(name: name, extra: extra?.toStruct()));
+    await client.stop(StopRequest(name: name, extra: extra?.toStruct()));
   }
 
   @override
   Future<bool> isMoving({Map<String, dynamic>? extra}) async {
-    final response = await _client.isMoving(IsMovingRequest(name: name));
+    final response = await client.isMoving(IsMovingRequest(name: name));
     return response.isMoving;
   }
 
   @override
   Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) async {
-    final response = await _client.doCommand(DoCommandRequest(name: name, command: command.toStruct()));
+    final response = await client.doCommand(DoCommandRequest(name: name, command: command.toStruct()));
     return response.result.toMap();
   }
 }

--- a/lib/src/resource/base.dart
+++ b/lib/src/resource/base.dart
@@ -1,3 +1,6 @@
+import 'package:grpc/grpc.dart';
+import 'package:grpc/grpc_connection_interface.dart';
+
 import '../gen/common/v1/common.pb.dart';
 
 const String resourceNamespaceRDK = 'rdk';
@@ -35,4 +38,10 @@ abstract class Resource {
   Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) {
     throw UnimplementedError();
   }
+}
+
+abstract class ResourceRPCClient<T extends Client> {
+  abstract ClientChannelBase channel;
+
+  T get client;
 }

--- a/lib/src/robot/client.dart
+++ b/lib/src/robot/client.dart
@@ -21,7 +21,7 @@ class RobotClientOptions {
   final DialOptions dialOptions;
 
   /// The frequency (in seconds) at which to check if the robot is still connected. 0 (zero) signifies no connection checks
-  final checkConnectionInterval = 1;
+  final checkConnectionInterval = 10;
 
   /// The frequency (in seconds) at which to attempt to reconnect a disconnected robot. 0 (zero) signifies no reconnection attempts
   final attemptReconnectInterval = 1;
@@ -59,7 +59,7 @@ class RobotClient {
     client._options = options.dialOptions;
     client._channel = await dial(url, options.dialOptions);
     client._client = RobotServiceClient(client._channel);
-    client._streamManager = StreamManager(client.channel as WebRtcClientChannel);
+    client._streamManager = StreamManager(client._channel as WebRtcClientChannel);
     await client.refresh();
     unawaited(client._checkConnection(interval: options.checkConnectionInterval, reconnectInterval: options.attemptReconnectInterval));
     return client;

--- a/lib/src/robot/client.dart
+++ b/lib/src/robot/client.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:grpc/grpc_connection_interface.dart';
+import 'package:logger/logger.dart';
 
 import '../domain/web_rtc/web_rtc_client/web_rtc_client.dart';
 import '../gen/common/v1/common.pb.dart';
@@ -10,10 +13,18 @@ import '../resource/registry.dart';
 import '../rpc/dial.dart';
 import '../viam_sdk.dart';
 
+Logger _logger = Logger();
+
 /// The options that define the behavior of the [RobotClient].
 class RobotClientOptions {
   /// Options for connecting to the robot
   final DialOptions dialOptions;
+
+  /// The frequency (in seconds) at which to check if the robot is still connected. 0 (zero) signifies no connection checks
+  final checkConnectionInterval = 1;
+
+  /// The frequency (in seconds) at which to attempt to reconnect a disconnected robot. 0 (zero) signifies no reconnection attempts
+  final attemptReconnectInterval = 1;
 
   RobotClientOptions() : dialOptions = DialOptions();
 
@@ -30,7 +41,10 @@ class RobotClientOptions {
 /// Obtain an instance of this client by using the function:
 ///     RobotClient.atAddress(...)
 class RobotClient {
-  late ClientChannelBase channel;
+  bool _connected = true;
+  late String _address;
+  late DialOptions _options;
+  late ClientChannelBase _channel;
   late RobotServiceClient _client;
   List<ResourceName> resourceNames = [];
   ResourceManager _manager = ResourceManager();
@@ -41,17 +55,20 @@ class RobotClient {
   /// Connect to a robot at the specified address with the provided options.
   static Future<RobotClient> atAddress(String url, RobotClientOptions options) async {
     final client = RobotClient._();
-    client.channel = await dial(url, options.dialOptions);
-    client._client = RobotServiceClient(client.channel);
+    client._address = url;
+    client._options = options.dialOptions;
+    client._channel = await dial(url, options.dialOptions);
+    client._client = RobotServiceClient(client._channel);
     await client.refresh();
+    unawaited(client._checkConnection(interval: options.checkConnectionInterval, reconnectInterval: options.attemptReconnectInterval));
     return client;
   }
 
   @Deprecated('This function will be removed prior to beta launch')
   static Future<RobotClient> withViam(Viam viam) async {
     final client = RobotClient._();
-    client.channel = viam.channel;
-    client._client = RobotServiceClient(client.channel);
+    client._channel = viam.channel;
+    client._client = RobotServiceClient(client._channel);
     await client.refresh();
     return client;
   }
@@ -70,8 +87,11 @@ class RobotClient {
       if (name.subtype == 'remote') {
         continue;
       }
+
+      _resetResourceChannel(name);
+
       try {
-        manager.register(name, Registry.instance.lookupSubtype(Subtype.fromResourceName(name)).rpcClientCreator(name.name, channel));
+        manager.register(name, Registry.instance.lookupSubtype(Subtype.fromResourceName(name)).rpcClientCreator(name.name, _channel));
       } catch (error) {
         continue;
       }
@@ -79,6 +99,63 @@ class RobotClient {
     resourceNames = response.resources;
     if (_manager.resources != manager.resources) {
       _manager = manager;
+    }
+  }
+
+  void _resetResourceChannel(ResourceName resourceName) {
+    if (_manager.resources.containsKey(resourceName)) {
+      final resource = _manager.getResource<ResourceRPCClient>(resourceName);
+      if (_channel != resource.channel) {
+        resource.channel = _channel;
+      }
+    }
+  }
+
+  Future<void> _checkConnection({required int interval, required int reconnectInterval}) async {
+    if (interval <= 0) interval = reconnectInterval;
+    if (interval <= 0 && reconnectInterval <= 0) return;
+
+    while (true) {
+      await Future.delayed(Duration(seconds: interval));
+
+      // Failure to grab resources could be for spurious, non-networking reasons. Try three times just to be safe.
+      for (int i = 0; i < 3; i++) {
+        try {
+          await _client.resourceNames(ResourceNamesRequest(), options: CallOptions(timeout: const Duration(seconds: 1)));
+          _connected = true;
+          break;
+        } catch (e) {
+          _connected = false;
+          await Future.delayed(const Duration(milliseconds: 100));
+        }
+      }
+      if (_connected) {
+        _logger.d('Robot still connected ${DateTime.now()}');
+      } else {
+        _logger.d('Lost connection to robot');
+        if (reconnectInterval > 0) {
+          _logger.d(
+              'Attempting to reconnect to the robot at $_address every $reconnectInterval ${(reconnectInterval > 1) ? 'seconds' : 'second'}');
+
+          while (!_connected) {
+            try {
+              final channel = await dial(_address, _options);
+              final client = RobotServiceClient(channel);
+              await client.resourceNames(ResourceNamesRequest());
+
+              _channel = channel;
+              _client = client;
+              await refresh();
+              _connected = true;
+              _logger.d('Successfully reconnected robot');
+            } catch (e) {
+              await _channel.shutdown();
+              _logger.d('Failed to reconnect, trying again in $reconnectInterval ${(reconnectInterval > 1) ? 'seconds' : 'second'}');
+              await Future.delayed(Duration(seconds: reconnectInterval));
+            }
+          }
+        }
+      }
     }
   }
 
@@ -90,7 +167,7 @@ class RobotClient {
   /// Get a WebRTC stream client with the given name
   StreamClient getStream(String name) {
     if (!_streams.containsKey(name)) {
-      _streams[name] = StreamClient(channel as WebRtcClientChannel);
+      _streams[name] = StreamClient(_channel as WebRtcClientChannel);
     }
     return _streams[name]!;
   }

--- a/lib/src/robot/client.dart
+++ b/lib/src/robot/client.dart
@@ -129,9 +129,8 @@ class RobotClient {
           await Future.delayed(const Duration(milliseconds: 100));
         }
       }
-      if (_connected) {
-        _logger.d('Robot still connected ${DateTime.now()}');
-      } else {
+
+      if (!_connected) {
         _logger.d('Lost connection to robot');
         if (reconnectInterval > 0) {
           _logger.d(

--- a/test/unit_test/components/movement_sensor_test.dart
+++ b/test/unit_test/components/movement_sensor_test.dart
@@ -66,6 +66,12 @@ class FakeMovementSensor extends MovementSensor {
     this.extra = extra;
     return Properties(angularVelocitySupported: false);
   }
+
+  @override
+  Future<Map<String, dynamic>> readings({Map<String, dynamic>? extra}) async {
+    this.extra = extra;
+    return {'test': 'test'};
+  }
 }
 
 void main() {
@@ -115,6 +121,10 @@ void main() {
     test('properties', () async {
       final result = await movementSensor.properties();
       expect(result.angularVelocitySupported, false);
+    });
+
+    test('readings', () async {
+      expect(await movementSensor.readings(), {'test': 'test'});
     });
 
     test('doCommand', () async {
@@ -265,6 +275,24 @@ void main() {
         final client = MovementSensorClient(name, channel);
         final result = await client.properties();
         expect(result.angularVelocitySupported, false);
+      });
+
+      test('readings', () async {
+        final client = MovementSensorClient(name, channel);
+        final result = await client.readings();
+        final expectedKeys = [
+          'position',
+          'altitude',
+          'linear_velocity',
+          'angular_velocity',
+          'linear_acceleration',
+          'compass',
+          'orientation'
+        ];
+        expect(result.keys, expectedKeys);
+
+        final expectedValues = [GeoPoint(latitude: 0.0), 0.0, Vector3(x: 0.0), Vector3(x: 0.0), Vector3(x: 0.0), 0.0, Orientation(oX: 0.0)];
+        expect(result.values, expectedValues);
       });
 
       test('doCommand', () async {


### PR DESCRIPTION
This PR adds robot reconnection logic, I copied the logic from our python SDK, so it ought to be very similar to that.

There are a couple of fly by's included here, i will call them out below.

Some follow up work will be reworking our stream client to reconnect as well. this is under construction currently in [this](https://github.com/viamrobotics/viam-flutter-sdk/pull/53) - i will address in a follow up.