### PR TITLE
[RSDK 3804] Fix webrtc streaming

### DIFF
--- a/lib/src/media/stream/client.dart
+++ b/lib/src/media/stream/client.dart
@@ -28,6 +28,25 @@ class StreamManager {
     _channel.rtcPeerConnection.onAddStream = (MediaStream stream) {
       _addStream(stream);
     };
+    _channel.rtcPeerConnection.onAddTrack = (stream, track) {
+      print('onAddTrack');
+      print(stream.id);
+      print(track.id);
+    };
+    _channel.rtcPeerConnection.onTrack = (event) {
+      print('onTrack');
+      print(event.streams);
+      print(event.track);
+    };
+    _channel.rtcPeerConnection.onRemoveTrack = (stream, track) {
+      print('onRemoveTrack');
+      print(stream.id);
+      print(track.id);
+    };
+    _channel.rtcPeerConnection.onRemoveStream = (MediaStream stream) {
+      print('onRemoveStream');
+      print(stream.id);
+    };
 
     _channel.rtcPeerConnection.onConnectionState = (state) {
       if (state == RTCPeerConnectionState.RTCPeerConnectionStateFailed ||

--- a/lib/src/media/stream/client.dart
+++ b/lib/src/media/stream/client.dart
@@ -24,28 +24,10 @@ class StreamManager {
 
   set channel(WebRtcClientChannel channel) {
     _channel = channel;
-
-    _channel.rtcPeerConnection.onAddStream = (MediaStream stream) {
-      _addStream(stream);
-    };
-    _channel.rtcPeerConnection.onAddTrack = (stream, track) {
-      print('onAddTrack');
-      print(stream.id);
-      print(track.id);
-    };
     _channel.rtcPeerConnection.onTrack = (event) {
-      print('onTrack');
-      print(event.streams);
-      print(event.track);
-    };
-    _channel.rtcPeerConnection.onRemoveTrack = (stream, track) {
-      print('onRemoveTrack');
-      print(stream.id);
-      print(track.id);
-    };
-    _channel.rtcPeerConnection.onRemoveStream = (MediaStream stream) {
-      print('onRemoveStream');
-      print(stream.id);
+      for (final stream in event.streams) {
+        _addStream(stream);
+      }
     };
 
     _channel.rtcPeerConnection.onConnectionState = (state) {

--- a/lib/src/rpc/dial.dart
+++ b/lib/src/rpc/dial.dart
@@ -184,7 +184,7 @@ Future<ClientChannelBase> _dialWebRtc(String address, DialOptions options) async
 
   // If trickleICE is enabled, set onIceCandidate handler
   if (!(options.webRtcOptions?.disableTrickleIce ?? config.disableTrickle)) {
-    final offer = await peerConnection.createOffer();
+    final offer = await peerConnection.createOffer({});
 
     peerConnection.onIceCandidate = (RTCIceCandidate candidate) async {
       await didSetRemoteDesc.future;
@@ -230,11 +230,7 @@ Future<ClientChannelBase> _dialWebRtc(String address, DialOptions options) async
     await peerConnection.setRemoteDescription(sdp);
 
     if (sdp.type == 'offer') {
-      final mediaConstraints = <String, dynamic>{
-        'audio': true,
-        'video': true,
-      };
-      final answer = await peerConnection.createAnswer(mediaConstraints);
+      final answer = await peerConnection.createAnswer();
       await peerConnection.setLocalDescription(answer);
       final sdpJsonString = _convertSDPtoJsonString(await peerConnection.getLocalDescription());
       final encodedBase64String = _encodeSDPJsonStringToBase64String(sdpJsonString);
@@ -244,14 +240,6 @@ Future<ClientChannelBase> _dialWebRtc(String address, DialOptions options) async
 
   // Call Signaling Service
   ResponseStream<CallResponse> callStream;
-  final offer = await peerConnection.createOffer({
-    'mandatory': {
-      'OfferToReceiveAudio': false,
-      'OfferToReceiveVideo': false,
-    }
-  });
-  await peerConnection.setLocalDescription(offer);
-
   final sdpJsonString = _convertSDPtoJsonString(await peerConnection.getLocalDescription());
   final encodedSdp = _encodeSDPJsonStringToBase64String(sdpJsonString);
   try {


### PR DESCRIPTION
There was a bug where navigating to a camera stream page, then leaving, then coming back wouldn't properly show the stream. 

Turns out, this was due to an extremely subtle bug caused by the way we were originally dialing. Long story short, we were creating offers that contradicted each other, putting the webrtc streams in a mismatched state. The streaming server saw this weird state and set the client to inactive, so we never got updated when a new stream got added (for the second navigation back to camera).