### PR TITLE
Close camera streams on robot close and when there are no more listeners

### DIFF
--- a/lib/src/media/stream/client.dart
+++ b/lib/src/media/stream/client.dart
@@ -119,7 +119,7 @@ class StreamManager {
 
   Future<void> closeAll() async {
     final futures = <Future>[];
-    final keys = _streams.keys.toList();
+    final keys = _streams.keys.toSet()..addAll(_clients.keys);
     for (var name in keys) {
       futures.add(_remove(name));
     }

--- a/lib/src/media/stream/client.dart
+++ b/lib/src/media/stream/client.dart
@@ -120,7 +120,7 @@ class StreamManager {
   Future<void> closeAll() async {
     final futures = <Future>[];
     final keys = _streams.keys.toSet()..addAll(_clients.keys);
-    for (var name in keys) {
+    for (final name in keys) {
       futures.add(_remove(name));
     }
     await Future.wait(futures);

--- a/lib/src/media/stream/client.dart
+++ b/lib/src/media/stream/client.dart
@@ -152,14 +152,16 @@ class StreamClient {
 
   /// Return a stream of [MediaStream], which can be used to display WebRTC video.
   Stream<MediaStream?> getStream() {
-    _internalListener.resume();
-    if (_stream != null) {
-      Future.delayed(const Duration(milliseconds: 100), () {
-        _streamController.add(_stream!);
-      });
-    } else {
-      _open(name);
+    if (_internalListener.isPaused) {
+      _internalListener.resume();
     }
+    Future.microtask(() {
+      if (_stream != null) {
+        _streamController.add(_stream!);
+      } else {
+        _open(name);
+      }
+    });
     return _streamController.stream;
   }
 

--- a/lib/src/robot/client.dart
+++ b/lib/src/robot/client.dart
@@ -205,6 +205,7 @@ class RobotClient {
     try {
       _checkConnectionTask?.cancel();
       _shouldAttemptReconnection = false;
+      await _streamManager.closeAll();
       _sessionsClient.stop();
       await _channel.shutdown();
     } catch (e) {

--- a/lib/widgets/camera_stream.dart
+++ b/lib/widgets/camera_stream.dart
@@ -28,16 +28,16 @@ class _ViamCameraStreamViewState extends State<ViamCameraStreamView> {
 
   @override
   void initState() {
-    _startStream();
     super.initState();
+    _startStream();
   }
 
   @override
-  void deactivate() {
+  void dispose() {
     _renderer.dispose();
     _streamSub.cancel();
     widget.streamClient.closeStream();
-    super.deactivate();
+    super.dispose();
   }
 
   Future<void> _startStream() async {

--- a/lib/widgets/camera_stream.dart
+++ b/lib/widgets/camera_stream.dart
@@ -21,7 +21,7 @@ class ViamCameraStreamView extends StatefulWidget {
 
 class _ViamCameraStreamViewState extends State<ViamCameraStreamView> {
   late RTCVideoRenderer _renderer;
-  late StreamSubscription<MediaStream> _streamSub;
+  late StreamSubscription<MediaStream?> _streamSub;
   Exception? _error;
   int _width = 160;
   int _height = 90;

--- a/lib/widgets/camera_stream.dart
+++ b/lib/widgets/camera_stream.dart
@@ -34,10 +34,10 @@ class _ViamCameraStreamViewState extends State<ViamCameraStreamView> {
 
   @override
   void deactivate() {
-    super.deactivate();
     _renderer.dispose();
-    widget.streamClient.closeStream();
     _streamSub.cancel();
+    widget.streamClient.closeStream();
+    super.deactivate();
   }
 
   Future<void> _startStream() async {


### PR DESCRIPTION
Close camera streams properly -- when there are no more listeners.

We reuse camera streams. Whenever someone asks for a stream, we return a cached copy if available. This stream might be new, cached and open, cached and previously closed (needs to be reopened), etc. We don't want the implementer to have to think about this. They should be able to call `close` whenever they are done, and we should figure out if it's time to actually close the stream (imagine they have multiple views with the same stream open, they should be able to close one without closing all).

This PR basically says, once there are no more subscribers to this stream, then close it for real. And finally, upon closing the robot, release all resources.