### PR TITLE
Remove delayed stop check

### DIFF
--- a/lib/widgets/resources/motor.dart
+++ b/lib/widgets/resources/motor.dart
@@ -42,10 +42,10 @@ class _ViamMotorWidgetState extends State<ViamMotorWidget> {
       });
       await Future.delayed(const Duration(milliseconds: 10));
       if (await widget.motor.isMoving()) {
-        if (power == 0) {
-          await widget.motor.stop();
-          setState(() {});
-        }
+        await widget.motor.stop();
+        setState(() {
+          power = 0;
+        });
       }
     } catch (e) {
       error = e as Error;
@@ -53,9 +53,6 @@ class _ViamMotorWidgetState extends State<ViamMotorWidget> {
   }
 
   void _handleSliderRelease(double power) {
-    setState(() {
-      this.power = power;
-    });
     if (autoStop) {
       stop();
     }


### PR DESCRIPTION
10ms is faster than any human reaction time, so it's virtually impossible that the user let go of the slider, then reengaged it within the 10ms time frame. I think it's safe to remove that check and just stop the motor again if it's still moving.

I'm not sure the underlying issue here, but using print statements, basically I found that the `setState(() { power = 0; });` sometimes wasn't actually setting the power to zero. Not entirely sure what's going on there, but I'm not going to fight the system. 

Also, removed the `setState` call in `_handleSliderRelease`, which is called `onChangeEnd`, because the [docs](https://api.flutter.dev/flutter/material/Slider/onChangeEnd.html) say:
> This callback shouldn't be used to update the slider [value](https://api.flutter.dev/flutter/material/Slider/value.html) (use [onChanged](https://api.flutter.dev/flutter/material/Slider/onChanged.html) for that)
