### PR TITLE
Add new data table

### DIFF
--- a/example/viam_robot_example_app/lib/main.dart
+++ b/example/viam_robot_example_app/lib/main.dart
@@ -9,6 +9,7 @@ import 'screens/base.dart';
 import 'screens/board.dart';
 import 'screens/gripper.dart';
 import 'screens/motor.dart';
+import 'screens/movement_sensor.dart';
 import 'screens/sensor.dart';
 import 'screens/servo.dart';
 import 'screens/stream.dart';
@@ -182,11 +183,10 @@ class _MyHomePageState extends State<MyHomePage> {
     if (rname.subtype == Servo.subtype.resourceSubtype) {
       return ServoScreen(servo: Servo.fromRobot(_robot, rname.name), resourceName: rname);
     }
-    return SensorScreen(
-        sensor: rname.subtype == Sensor.subtype.resourceSubtype
-            ? Sensor.fromRobot(_robot, rname.name)
-            : MovementSensor.fromRobot(_robot, rname.name),
-        resourceName: rname);
+    if (rname.subtype == MovementSensor.subtype.resourceSubtype) {
+      return MovementSensorScreen(movementSensor: MovementSensor.fromRobot(_robot, rname.name), resourceName: rname);
+    }
+    return SensorScreen(sensor: Sensor.fromRobot(_robot, rname.name), resourceName: rname);
   }
 
   @override

--- a/example/viam_robot_example_app/lib/screens/movement_sensor.dart
+++ b/example/viam_robot_example_app/lib/screens/movement_sensor.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
+import 'package:viam_sdk/viam_sdk.dart';
+import 'package:viam_sdk/widgets.dart';
+
+class MovementSensorScreen extends StatelessWidget {
+  final MovementSensor movementSensor;
+  final ResourceName resourceName;
+
+  const MovementSensorScreen({super.key, required this.movementSensor, required this.resourceName});
+
+  Future<Map<String, dynamic>> _getReadings({Map<String, dynamic>? extra}) async {
+    final Map<String, dynamic> readings = {};
+    try {
+      final Position pos = await movementSensor.position();
+      readings['position'] = pos.coordinates;
+      readings['altitude'] = pos.altitude;
+    } catch (exception) {
+      // Do nothing on error
+    }
+
+    try {
+      final lv = await movementSensor.linearVelocity();
+      readings['linear_velocity'] = lv;
+    } catch (exception) {
+      // Do nothing on error
+    }
+
+    try {
+      final av = await movementSensor.angularVelocity();
+      readings['angular_velocity'] = av;
+    } catch (exception) {
+      // Do nothing on error
+    }
+
+    try {
+      final la = await movementSensor.linearAcceleration();
+      readings['linear_acceleration'] = la;
+    } catch (exception) {
+      // Do nothing on error
+    }
+
+    try {
+      final comp = await movementSensor.compassHeading();
+      readings['compass'] = comp;
+    } catch (exception) {
+      // Do nothing on error
+    }
+
+    try {
+      final orient = await movementSensor.orientation();
+      readings['orientation'] = orient;
+    } catch (exception) {
+      // Do nothing on error
+    }
+
+    return readings;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PlatformScaffold(
+      appBar: PlatformAppBar(
+        title: Text(resourceName.name.toUpperCase()),
+      ),
+      iosContentPadding: true,
+      body: Center(
+        child: Column(
+          children: [
+            const Padding(padding: EdgeInsets.symmetric(vertical: 8, horizontal: 0)),
+            PlatformText(
+              '${resourceName.namespace}:${resourceName.type}:${resourceName.subtype}/${resourceName.name}',
+              style: const TextStyle(fontWeight: FontWeight.w300),
+            ),
+            const Padding(padding: EdgeInsets.symmetric(vertical: 8, horizontal: 0)),
+            ViamRefreshableDataTable(getData: _getReadings),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -2,6 +2,7 @@ export 'widgets/button.dart';
 export 'widgets/camera_stream.dart';
 export 'widgets/joystick.dart';
 export 'widgets/multi_camera_stream.dart';
+export 'widgets/refreshable_data_table.dart';
 export 'widgets/resources/base.dart';
 export 'widgets/resources/board.dart';
 export 'widgets/resources/gripper.dart';

--- a/lib/widgets/refreshable_data_table.dart
+++ b/lib/widgets/refreshable_data_table.dart
@@ -1,0 +1,136 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'button.dart';
+
+/// A widget to display data from a [Map]
+///
+/// Displays the data in a simple data table, with options for
+/// displaying the time the data were retrieved,
+/// automatic refreshing, and for controlling the refresh.
+class ViamRefreshableDataTable extends StatefulWidget {
+  /// The function to get and refresh the data
+  final FutureOr<Map<String, dynamic>> Function({Map<String, dynamic>? extra}) getData;
+
+  /// How often to automatically refresh the data
+  final Duration? refreshInterval;
+
+  /// Whether to display the time the data were retrieved
+  final bool showLastRefreshed;
+
+  /// Whether to display controls for refreshing data
+  final bool showRefreshControls;
+
+  const ViamRefreshableDataTable({
+    super.key,
+    required this.getData,
+    this.refreshInterval = const Duration(seconds: 1),
+    this.showLastRefreshed = true,
+    this.showRefreshControls = true,
+  });
+
+  @override
+  State<ViamRefreshableDataTable> createState() {
+    return _ViamRefreshableDataTableState();
+  }
+}
+
+class _ViamRefreshableDataTableState extends State<ViamRefreshableDataTable> {
+  Map<String, dynamic> readings = {};
+  Timer? timer;
+  DateTime? lastRefreshed;
+  bool isPaused = false;
+
+  Future<void> getReadings() async {
+    try {
+      final response = await widget.getData();
+      setState(
+        () {
+          readings = Map.fromEntries(response.entries.toList()..sort((a, b) => a.key.compareTo(b.key)));
+          lastRefreshed = DateTime.now();
+        },
+      );
+    } catch (e) {
+      Text('Error: $e');
+    }
+  }
+
+  void refresh() {
+    getReadings();
+  }
+
+  void playPause() {
+    setState(() => isPaused = !isPaused);
+    if (isPaused) {
+      timer?.cancel();
+    } else {
+      getReadings();
+      _createTimer();
+    }
+  }
+
+  void _createTimer() {
+    if (widget.refreshInterval != null) {
+      timer = Timer.periodic(widget.refreshInterval!, (_) {
+        refresh();
+      });
+    }
+  }
+
+  String formattedDate(DateTime date) {
+    return DateFormat('yyyy-MM-dd HH:mm:ss:SS').format(date);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    getReadings();
+    _createTimer();
+  }
+
+  @override
+  void dispose() {
+    timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        DataTable(
+            columns: const <DataColumn>[DataColumn(label: Text('Reading')), DataColumn(label: Text('Value'))],
+            rows: readings.keys.map((e) => DataRow(cells: [DataCell(Text(e)), DataCell(Text(readings[e].toString()))])).toList()),
+        if (widget.showLastRefreshed && lastRefreshed != null)
+          Column(children: [
+            const SizedBox(height: 8),
+            Text('Updated at: ${formattedDate(lastRefreshed!)}'),
+          ]),
+        if (widget.showRefreshControls)
+          Column(children: [
+            const SizedBox(height: 8),
+            Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+              if (widget.refreshInterval != null)
+                ViamButton(
+                  onPressed: playPause,
+                  text: isPaused ? 'Play' : 'Pause',
+                  icon: isPaused ? Icons.play_arrow : Icons.pause,
+                  variant: ViamButtonVariant.iconOnly,
+                  style: ViamButtonFillStyle.ghost,
+                ),
+              const SizedBox(width: 8),
+              ViamButton(
+                onPressed: refresh,
+                text: 'Refresh',
+                icon: Icons.refresh,
+                variant: ViamButtonVariant.iconOnly,
+                style: ViamButtonFillStyle.ghost,
+              ),
+            ]),
+          ]),
+      ],
+    );
+  }
+}

--- a/lib/widgets/resources/arm.dart
+++ b/lib/widgets/resources/arm.dart
@@ -9,9 +9,9 @@ class ViamArmWidget extends StatefulWidget {
   final Arm arm;
 
   const ViamArmWidget({
-    Key? key,
+    super.key,
     required this.arm,
-  }) : super(key: key);
+  });
 
   @override
   State<ViamArmWidget> createState() => _ViamArmWidgetState();

--- a/lib/widgets/resources/base.dart
+++ b/lib/widgets/resources/base.dart
@@ -19,11 +19,11 @@ class ViamBaseWidget extends StatefulWidget {
   final RobotClient robotClient;
 
   const ViamBaseWidget({
-    Key? key,
+    super.key,
     required this.base,
     required this.cameras,
     required this.robotClient,
-  }) : super(key: key);
+  });
 
   @override
   State<ViamBaseWidget> createState() => _ViamBaseWidgetState();

--- a/lib/widgets/resources/board.dart
+++ b/lib/widgets/resources/board.dart
@@ -13,9 +13,9 @@ class ViamBoardWidget extends StatefulWidget {
   final Board board;
 
   const ViamBoardWidget({
-    Key? key,
+    super.key,
     required this.board,
-  }) : super(key: key);
+  });
 
   @override
   State<ViamBoardWidget> createState() => _ViamBoardWidgetState();

--- a/lib/widgets/resources/gripper.dart
+++ b/lib/widgets/resources/gripper.dart
@@ -21,11 +21,11 @@ class ViamGripperWidget extends StatefulWidget {
   final RobotClient robotClient;
 
   const ViamGripperWidget({
-    Key? key,
+    super.key,
     required this.gripper,
     required this.cameras,
     required this.robotClient,
-  }) : super(key: key);
+  });
 
   @override
   State<ViamGripperWidget> createState() => _ViamGripperWidgetState();

--- a/lib/widgets/resources/motor.dart
+++ b/lib/widgets/resources/motor.dart
@@ -10,7 +10,7 @@ class ViamMotorWidget extends StatefulWidget {
   /// The [Motor]
   final Motor motor;
 
-  const ViamMotorWidget({Key? key, required this.motor}) : super(key: key);
+  const ViamMotorWidget({super.key, required this.motor});
 
   @override
   State<ViamMotorWidget> createState() {

--- a/lib/widgets/resources/sensor.dart
+++ b/lib/widgets/resources/sensor.dart
@@ -1,137 +1,21 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:viam_sdk/viam_sdk.dart';
-
-import '../button.dart';
+import 'package:viam_sdk/widgets/refreshable_data_table.dart';
 
 /// A widget to display data from a [Sensor].
 ///
-/// Displays the data in a simple data table, with options for
-/// displaying the time the data were retrieved,
-/// automatic refreshing, and for controlling the refresh.
-class ViamSensorWidget extends StatefulWidget {
+/// Displays the data in a simple data table.
+class ViamSensorWidget extends StatelessWidget {
   /// The [Sensor]
   final Sensor sensor;
 
-  /// How often to automatically refresh the data
-  final Duration? refreshInterval;
-
-  /// Whether to display the time the data were retrieved
-  final bool showLastRefreshed;
-
-  /// Whether to display controls for refreshing data
-  final bool showRefreshControls;
-
   const ViamSensorWidget({
-    Key? key,
+    super.key,
     required this.sensor,
-    this.refreshInterval = const Duration(seconds: 1),
-    this.showLastRefreshed = true,
-    this.showRefreshControls = true,
-  }) : super(key: key);
-
-  @override
-  State<ViamSensorWidget> createState() {
-    return _ViamSensorWidgetState();
-  }
-}
-
-class _ViamSensorWidgetState extends State<ViamSensorWidget> {
-  Map<String, dynamic> readings = {};
-  Timer? timer;
-  DateTime? lastRefreshed;
-  bool isPaused = false;
-
-  Future<void> getReadings() async {
-    try {
-      final response = await widget.sensor.readings();
-      setState(
-        () {
-          readings = Map.fromEntries(response.entries.toList()..sort((a, b) => a.key.compareTo(b.key)));
-          lastRefreshed = DateTime.now();
-        },
-      );
-    } catch (e) {
-      Text('Error: $e');
-    }
-  }
-
-  void refresh() {
-    getReadings();
-  }
-
-  void playPause() {
-    setState(() => isPaused = !isPaused);
-    if (isPaused) {
-      timer?.cancel();
-    } else {
-      getReadings();
-      _createTimer();
-    }
-  }
-
-  void _createTimer() {
-    if (widget.refreshInterval != null) {
-      timer = Timer.periodic(widget.refreshInterval!, (_) {
-        refresh();
-      });
-    }
-  }
-
-  String formattedDate(DateTime date) {
-    return DateFormat('yyyy-MM-dd HH:mm:ss:SS').format(date);
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    getReadings();
-    _createTimer();
-  }
-
-  @override
-  void dispose() {
-    timer?.cancel();
-    super.dispose();
-  }
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        DataTable(
-            columns: const <DataColumn>[DataColumn(label: Text('Reading')), DataColumn(label: Text('Value'))],
-            rows: readings.keys.map((e) => DataRow(cells: [DataCell(Text(e)), DataCell(Text(readings[e].toString()))])).toList()),
-        if (widget.showLastRefreshed && lastRefreshed != null)
-          Column(children: [
-            const SizedBox(height: 8),
-            Text('Updated at: ${formattedDate(lastRefreshed!)}'),
-          ]),
-        if (widget.showRefreshControls)
-          Column(children: [
-            const SizedBox(height: 8),
-            Row(mainAxisAlignment: MainAxisAlignment.center, children: [
-              if (widget.refreshInterval != null)
-                ViamButton(
-                  onPressed: playPause,
-                  text: isPaused ? 'Play' : 'Pause',
-                  icon: isPaused ? Icons.play_arrow : Icons.pause,
-                  variant: ViamButtonVariant.iconOnly,
-                  style: ViamButtonFillStyle.ghost,
-                ),
-              const SizedBox(width: 8),
-              ViamButton(
-                onPressed: refresh,
-                text: 'Refresh',
-                icon: Icons.refresh,
-                variant: ViamButtonVariant.iconOnly,
-                style: ViamButtonFillStyle.ghost,
-              ),
-            ]),
-          ]),
-      ],
-    );
+    return ViamRefreshableDataTable(getData: sensor.readings);
   }
 }

--- a/lib/widgets/resources/servo.dart
+++ b/lib/widgets/resources/servo.dart
@@ -5,7 +5,7 @@ import 'package:viam_sdk/widgets.dart';
 class ViamServoWidget extends StatefulWidget {
   final Servo servo;
 
-  const ViamServoWidget({Key? key, required this.servo}) : super(key: key);
+  const ViamServoWidget({super.key, required this.servo});
 
   @override
   State<ViamServoWidget> createState() {

--- a/test/widget_tests/refreshable_data_table_test.dart
+++ b/test/widget_tests/refreshable_data_table_test.dart
@@ -6,9 +6,9 @@ import '../test_utils.dart';
 import '../unit_test/components/sensor_test.dart';
 
 void main() {
-  group('ViamSensorWidget', () {
+  group('ViamRefreshableDataTableTest', () {
     testWidgets('displays data', (tester) async {
-      final widget = TestableWidget(child: ViamSensorWidget(sensor: FakeSensor('sensor')));
+      final widget = TestableWidget(child: ViamRefreshableDataTable(getData: FakeSensor('sensor').readings));
       await tester.pumpWidget(widget);
 
       final dataTable = find.byType(DataTable);
@@ -17,7 +17,7 @@ void main() {
     });
 
     testWidgets('shows last refresh time', (tester) async {
-      final widget = TestableWidget(child: ViamSensorWidget(sensor: FakeSensor('sensor'), showLastRefreshed: true));
+      final widget = TestableWidget(child: ViamRefreshableDataTable(getData: FakeSensor('sensor').readings, showLastRefreshed: true));
       await tester.pumpWidget(widget);
 
       final refreshButton = find.widgetWithIcon(ViamButton, Icons.refresh);
@@ -30,7 +30,7 @@ void main() {
     });
 
     testWidgets('hides last refresh time', (tester) async {
-      final widget = TestableWidget(child: ViamSensorWidget(sensor: FakeSensor('sensor'), showLastRefreshed: false));
+      final widget = TestableWidget(child: ViamRefreshableDataTable(getData: FakeSensor('sensor').readings, showLastRefreshed: false));
       await tester.pumpWidget(widget);
 
       final refreshButton = find.widgetWithIcon(ViamButton, Icons.refresh);
@@ -43,7 +43,7 @@ void main() {
     });
 
     testWidgets('shows refresh controls', (tester) async {
-      final widget = TestableWidget(child: ViamSensorWidget(sensor: FakeSensor('sensor'), showRefreshControls: true));
+      final widget = TestableWidget(child: ViamRefreshableDataTable(getData: FakeSensor('sensor').readings, showRefreshControls: true));
       await tester.pumpWidget(widget);
 
       final playButton = find.widgetWithIcon(ViamButton, Icons.play_arrow);
@@ -62,7 +62,7 @@ void main() {
     });
 
     testWidgets('hides refresh controls', (tester) async {
-      final widget = TestableWidget(child: ViamSensorWidget(sensor: FakeSensor('sensor'), showRefreshControls: false));
+      final widget = TestableWidget(child: ViamRefreshableDataTable(getData: FakeSensor('sensor').readings, showRefreshControls: false));
       await tester.pumpWidget(widget);
 
       final playButton = find.widgetWithIcon(ViamButton, Icons.play_arrow);
@@ -75,7 +75,7 @@ void main() {
     });
 
     testWidgets('hides play/pause when refresh interval is null', (tester) async {
-      final widget = TestableWidget(child: ViamSensorWidget(sensor: FakeSensor('sensor'), refreshInterval: null));
+      final widget = TestableWidget(child: ViamRefreshableDataTable(getData: FakeSensor('sensor').readings, refreshInterval: null));
       await tester.pumpWidget(widget);
 
       final playButton = find.widgetWithIcon(ViamButton, Icons.play_arrow);


### PR DESCRIPTION
Since `MovementSensor` is no longer a sensor type, we can't just reuse the `SensorWidget` like we used to. So I created a new data table to reuse across sensors and movement sensors and anything else that provides a map.

flyby: change the `{Key? key}` to `{super.key}`