### PR TITLE
Add new exception type for mdns

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ Make sure your project meets the minimum requirements:
 
 `flutter pub add viam_sdk`
 
+### Update Info.plist
+
+If you are building for Apple platforms, you may have to update your app's `Info.plist`. `NSLocalNetworkUsageDescription` is needed to establish stable WebRTC connections, and `NSBonjourServices` is required to connect to local devices via mDNS.
+
+```plist
+<key>NSLocalNetworkUsageDescription</key>
+<string>Viam requires access to your devices local network to connect to your devices.</string>
+<key>NSBonjourServices</key>
+<array>
+    <string>_rpc._tcp</string>
+</array>
+```
+
 ## Usage
 
 You can use the Viam SDK to connect to an existing robot (to create a robot, view the [documentation](https://docs.viam.com/) or [try Viam](https://docs.viam.com/try-viam/)).

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -1,9 +1,0 @@
-/// Error thrown with connection is lost
-class ConnectionLostError {
-  final String? message;
-
-  const ConnectionLostError([this.message]);
-
-  @override
-  String toString() => message ?? 'ConnectionLostError';
-}

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -1,0 +1,19 @@
+/// Error thrown with connection is lost
+class ConnectionLostException implements Exception {
+  final String? message;
+
+  const ConnectionLostException([this.message]);
+
+  @override
+  String toString() => message ?? 'ConnectionLostError';
+}
+
+/// Error thrown when mDNS fails to find a match on the local network
+class NotLocalAddressException implements Exception {
+  final String address;
+
+  const NotLocalAddressException(this.address);
+
+  @override
+  String toString() => 'Address not on local network';
+}

--- a/lib/src/rpc/dial.dart
+++ b/lib/src/rpc/dial.dart
@@ -8,6 +8,7 @@ import 'package:grpc/grpc_connection_interface.dart';
 import 'package:grpc/grpc_or_grpcweb.dart';
 import 'package:logger/logger.dart';
 
+import '../exceptions.dart';
 import '../gen/proto/rpc/v1/auth.pb.dart' as pb;
 import '../gen/proto/rpc/v1/auth.pbgrpc.dart';
 import '../gen/proto/rpc/webrtc/v1/signaling.pbgrpc.dart';
@@ -123,6 +124,8 @@ Future<ClientChannelBase> dial(String address, DialOptions? options, String Func
         .._usingMdns = true
         ..authEntity = address;
       return _dialWebRtc(mdnsUri, dialOptsCopy, sessionCallback);
+    } on NotLocalAddressException catch (e) {
+      _logger.d(e.toString());
     } catch (e) {
       _logger.d('Error dialing with mDNS; falling back to other methods', error: e);
     }
@@ -158,8 +161,7 @@ Future<String> searchMdns(String address) async {
   }
 
   await discovery.stop();
-
-  throw Exception('Address not on local network');
+  throw NotLocalAddressException(address);
 }
 
 Future<ClientChannelBase> _dialDirectGrpc(String address, DialOptions options, String Function() sessionCallback) async {

--- a/lib/src/rpc/web_rtc/web_rtc_transport_stream.dart
+++ b/lib/src/rpc/web_rtc/web_rtc_transport_stream.dart
@@ -5,7 +5,7 @@ import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:grpc/grpc.dart';
 import 'package:grpc/grpc_connection_interface.dart';
 
-import '../../errors.dart';
+import '../../exceptions.dart';
 import '../../gen/proto/rpc/webrtc/v1/grpc.pb.dart' as grpc;
 import 'web_rtc_client.dart';
 
@@ -63,7 +63,7 @@ class WebRtcTransportStream extends GrpcTransportStream {
       if (connectionState == RTCPeerConnectionState.RTCPeerConnectionStateFailed ||
           connectionState == RTCPeerConnectionState.RTCPeerConnectionStateDisconnected) {
         onRequestFailure(
-          const ConnectionLostError('RTCPeerConnection lost'),
+          const ConnectionLostException('RTCPeerConnection lost'),
           StackTrace.current,
         );
         return;


### PR DESCRIPTION
`errors` should be called `exceptions` when they can be handled by the user.

Also, this adds a new exception type to differentiate errors in mDNS: whether the robot was local vs other issues