### PR TITLE
base auto stop bug fix

### DIFF
--- a/lib/widgets/joystick.dart
+++ b/lib/widgets/joystick.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_joystick/flutter_joystick.dart';
 import 'package:viam_sdk/viam_sdk.dart';
@@ -19,6 +21,7 @@ class ViamBaseJoystick extends StatefulWidget {
 class _ViamBaseJoystickState extends State<ViamBaseJoystick> {
   num y = 0;
   num z = 0;
+  bool touchActive = false;
 
   @override
   Widget build(BuildContext context) {
@@ -28,12 +31,14 @@ class _ViamBaseJoystickState extends State<ViamBaseJoystick> {
         const SizedBox(height: 16),
         Joystick(
           listener: callSetPower,
+          onStickDragEnd: () => callSetPower(StickDragDetails(0, 0)),
         )
       ],
     );
   }
 
   void callSetPower(StickDragDetails details) {
+    touchActive = (details.x != 0 && details.y != 0);
     widget.base.setPower(
       Vector3()..y = details.y * -1,
       Vector3()..z = details.x * -1,
@@ -41,6 +46,20 @@ class _ViamBaseJoystickState extends State<ViamBaseJoystick> {
     setState(() {
       y = details.y * -100;
       z = details.x * -100;
+    });
+
+    // When the client has spotty network conditions,
+    // the joystick has a tendency to cause the machine
+    // to hang on the most recent setPower call and keep moving
+    // after the touch has been released. This is a workaround that
+    // will work faster than the session being canceled,
+    // if network conditions allowed. The session being canceled
+    // will eventually stop the base if network conditions become too spotty.
+    Future.delayed(const Duration(milliseconds: 100)).then((_) async {
+      final isMoving = await widget.base.isMoving();
+      if (isMoving && !touchActive) {
+        unawaited(widget.base.stop());
+      }
     });
   }
 }

--- a/lib/widgets/joystick.dart
+++ b/lib/widgets/joystick.dart
@@ -38,7 +38,7 @@ class _ViamBaseJoystickState extends State<ViamBaseJoystick> {
   }
 
   void callSetPower(StickDragDetails details) {
-    touchActive = (details.x != 0 && details.y != 0);
+    touchActive = (details.x != 0 || details.y != 0);
     widget.base.setPower(
       Vector3()..y = details.y * -1,
       Vector3()..z = details.x * -1,


### PR DESCRIPTION
I added a perhaps too lengthy comment describing some of the thoughts on this issue in the code, I will explain here as well.

Essentially things tend to work well in normal network conditions, but as soon as the client is in spotty conditions, not enough to end the session but enough to garble the order of some calls or have some not make it through, the joystick widget tends to not auto stop not upon touch release and the base will continue to move in whatever the last command was.

My first thought was to shorten the sessions heartbeat interval, but that is configured per robot and not per client.

So I ended up tracking the touch locally in the widgets state and sending a stop command if the base is still moving but touch has been released, I check 100 milliseconds after each call.

If network conditions allow this will stop the base sooner than the ending session would, though if network conditions do not allow the stop call to make it through the ending session will eventually stop base.

Another option would be to continually check if the bass is moving and if the touch is active every 100ms during the widgets life cycle. I didn't opt for that to limit extraneous calls.