### PR TITLE
APP-3318 - Fix sticky motor slider

### DIFF
--- a/lib/widgets/resources/motor.dart
+++ b/lib/widgets/resources/motor.dart
@@ -36,20 +36,21 @@ class _ViamMotorWidgetState extends State<ViamMotorWidget> {
 
   Future<void> stop() async {
     try {
-      unawaited(widget.motor.setPower(0));
       setState(() {
         power = 0;
       });
+      await widget.motor.stop();
+
       // Sometimes the motor does not honor the first Stop call
       // So we wait a small amount of time and try again.
       await Future.delayed(const Duration(milliseconds: 10));
       if (await widget.motor.isMoving()) {
-        await widget.motor.stop();
-        await widget.motor.setPower(0);
-
         setState(() {
           power = 0;
         });
+
+        await widget.motor.setPower(0);
+        await widget.motor.stop();
       }
     } catch (e) {
       error = e as Error;

--- a/lib/widgets/resources/motor.dart
+++ b/lib/widgets/resources/motor.dart
@@ -25,10 +25,10 @@ class _ViamMotorWidgetState extends State<ViamMotorWidget> {
 
   Future<void> setPower(double power) async {
     try {
-      await widget.motor.setPower(power);
       setState(() {
         this.power = power;
       });
+      await widget.motor.setPower(power);
     } catch (e) {
       error = e as Error;
     }

--- a/lib/widgets/resources/motor.dart
+++ b/lib/widgets/resources/motor.dart
@@ -36,7 +36,7 @@ class _ViamMotorWidgetState extends State<ViamMotorWidget> {
 
   Future<void> stop() async {
     try {
-      await widget.motor.stop();
+      await widget.motor.setPower(0);
       setState(() {
         power = 0;
       });

--- a/lib/widgets/resources/motor.dart
+++ b/lib/widgets/resources/motor.dart
@@ -49,7 +49,6 @@ class _ViamMotorWidgetState extends State<ViamMotorWidget> {
           power = 0;
         });
 
-        await widget.motor.setPower(0);
         await widget.motor.stop();
       }
     } catch (e) {

--- a/lib/widgets/resources/motor.dart
+++ b/lib/widgets/resources/motor.dart
@@ -36,7 +36,7 @@ class _ViamMotorWidgetState extends State<ViamMotorWidget> {
 
   Future<void> stop() async {
     try {
-      await widget.motor.setPower(0);
+      unawaited(widget.motor.setPower(0));
       setState(() {
         power = 0;
       });
@@ -45,6 +45,8 @@ class _ViamMotorWidgetState extends State<ViamMotorWidget> {
       await Future.delayed(const Duration(milliseconds: 10));
       if (await widget.motor.isMoving()) {
         await widget.motor.stop();
+        await widget.motor.setPower(0);
+
         setState(() {
           power = 0;
         });


### PR DESCRIPTION
On Plus/Max sized iphones, the call to set state after awaiting setPower would happen sometimes after the call to stop had gone through, causing the slider to stick after release, even when the toggle to stop after release was enabled.

Moving the setState to before the awaited method calls fixes this issue.

I considered making the calls to setPower and stop `unawaited()` - but then we'd lose our error handling from the try catch.

We could also use the older convention of not using async/await and instead use the Future.onError() callback, to populate the error object. But I opted for using async and await because they are more idiomatic.
