### PR TITLE
RSDK-5424 - fix video stream on flutter web

### DIFF
--- a/lib/widgets/camera_stream.dart
+++ b/lib/widgets/camera_stream.dart
@@ -46,7 +46,7 @@ class _ViamCameraStreamViewState extends State<ViamCameraStreamView> {
     final stream = widget.streamClient.getStream();
     _streamSub = stream.listen((event) {
       _error = null;
-      _renderer.setSrcObject(stream: event);
+      _renderer.srcObject = event;
       _renderer.onResize = () {
         setState(() {
           if (_renderer.videoWidth > 0 && _renderer.videoHeight > 0) {


### PR DESCRIPTION
this issue came up again and I finally wanted to put it to rest.

I combed through the webRTC examples where they support web and they didn't have to do anything different to handle the RTCVideoStream for web vs other platforms.

The only difference I noticed was the setter they used for the srcObject. I tried changing it in our code to what they used and now video works on web as well as mobile platforms.

https://github.com/viamrobotics/viam-flutter-sdk/assets/22106496/c25f7673-285d-41b1-8007-f5549b1d8e3c