### PR TITLE
RSDK-6116: Mobile app should auto refresh board's analog readings

### DIFF
--- a/lib/widgets/resources/board.dart
+++ b/lib/widgets/resources/board.dart
@@ -13,10 +13,12 @@ import '../button.dart';
 class ViamBoardWidget extends StatefulWidget {
   /// The [Board]
   final Board board;
+  final Duration refreshInterval;
 
   const ViamBoardWidget({
     super.key,
     required this.board,
+    this.refreshInterval = const Duration(seconds: 1),
   });
 
   @override
@@ -36,7 +38,6 @@ class _ViamBoardWidgetState extends State<ViamBoardWidget> {
   final _pwmFreqFormKey = GlobalKey<FormState>();
   int pwmFrequency = 0;
 
-  Duration refreshInterval = const Duration(seconds: 1);
   Timer? timer;
 
   BoardStatus status = const BoardStatus({}, {});
@@ -53,7 +54,7 @@ class _ViamBoardWidgetState extends State<ViamBoardWidget> {
   }
 
   void _createTimer() {
-    timer = Timer.periodic(refreshInterval, (_) {
+    timer = Timer.periodic(widget.refreshInterval, (_) {
       refresh();
     });
   }

--- a/lib/widgets/resources/board.dart
+++ b/lib/widgets/resources/board.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:viam_sdk/viam_sdk.dart';
@@ -34,6 +36,9 @@ class _ViamBoardWidgetState extends State<ViamBoardWidget> {
   final _pwmFreqFormKey = GlobalKey<FormState>();
   int pwmFrequency = 0;
 
+  Duration refreshInterval = const Duration(seconds: 1);
+  Timer? timer;
+
   BoardStatus status = const BoardStatus({}, {});
 
   Future<void> _fetchStatus() async {
@@ -43,10 +48,21 @@ class _ViamBoardWidgetState extends State<ViamBoardWidget> {
     });
   }
 
+  void refresh() {
+    _fetchStatus();
+  }
+
+  void _createTimer() {
+    timer = Timer.periodic(refreshInterval, (_) {
+      refresh();
+    });
+  }
+
   @override
   void initState() {
     super.initState();
     _fetchStatus();
+    _createTimer();
   }
 
   void _dismissKeyboard() {

--- a/lib/widgets/resources/board.dart
+++ b/lib/widgets/resources/board.dart
@@ -65,6 +65,12 @@ class _ViamBoardWidgetState extends State<ViamBoardWidget> {
     _createTimer();
   }
 
+  @override
+  void dispose() {
+    timer?.cancel();
+    super.dispose();
+  }
+
   void _dismissKeyboard() {
     final currentFocus = FocusScope.of(context);
     if (!currentFocus.hasPrimaryFocus) {

--- a/lib/widgets/resources/board.dart
+++ b/lib/widgets/resources/board.dart
@@ -13,6 +13,9 @@ import '../button.dart';
 class ViamBoardWidget extends StatefulWidget {
   /// The [Board]
   final Board board;
+
+  /// The refresh interval
+  /// This field determines how frequently the user wants to auto refresh the board's status readings.
   final Duration refreshInterval;
 
   const ViamBoardWidget({


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-6116)

In this PR, I modified the board card to refresh board readings every second just like we do for the sensor readings.