### PR TITLE
RSDK-6515 Add dial timeout and stats

### DIFF
--- a/lib/src/rpc/dial.dart
+++ b/lib/src/rpc/dial.dart
@@ -221,6 +221,11 @@ Future _logConnectionStats(Stopwatch webrtcDialSW, RTCPeerConnection peerConnect
     // NOTE(benjirewis): some magic-string-usage here; there are not great
     // constants in the WebRTC library for these fields.
     if (stat.type == 'candidate-pair' && stat.values['nominated']) {
+      // Use 'lastPacketSentTimestamp' on candidate pair to estimate when the
+      // pair was nominated.
+      final double lpst = stat.values['lastPacketSentTimestamp'];
+      final DateTime nominatedTime = DateTime.fromMillisecondsSinceEpoch(lpst.toInt());
+
       final String lcid = stat.values['localCandidateId'];
       final String rcid = stat.values['remoteCandidateId'];
       for (var innerStat in stats) {
@@ -228,13 +233,13 @@ Future _logConnectionStats(Stopwatch webrtcDialSW, RTCPeerConnection peerConnect
           final type = innerStat.values['candidateType'];
           final addr = innerStat.values['address'];
           final port = innerStat.values['port'];
-          _logger.d('STATS: chose $type local candidate with IP $addr:$port');
+          _logger.d('STATS: chose $type local candidate with IP $addr:$port @ $nominatedTime');
         }
         if (innerStat.id == rcid) {
           final type = innerStat.values['candidateType'];
           final addr = innerStat.values['address'];
           final port = innerStat.values['port'];
-          _logger.d('STATS: chose $type remote candidate with IP $addr:$port');
+          _logger.d('STATS: chose $type remote candidate with IP $addr:$port @ $nominatedTime');
         }
       }
     }

--- a/lib/src/rpc/dial.dart
+++ b/lib/src/rpc/dial.dart
@@ -142,15 +142,15 @@ Future<ClientChannelBase> dial(String address, DialOptions? options, String Func
   if (address.contains('.local.') || address.contains('localhost')) {
     disableWebRtc = true;
   }
-  final chan;
+  final Future<ClientChannelBase> chan;
   if (disableWebRtc) {
-    chan = _dialDirectGrpc(address, opts, sessionCallback).timeout(opts.timeout);
+    chan = _dialDirectGrpc(address, opts, sessionCallback);
   } else {
-    chan = _dialWebRtc(address, opts, sessionCallback).timeout(opts.timeout);
+    chan = _dialWebRtc(address, opts, sessionCallback);
   }
   dialSW.stop();
   _logger.d('STATS: dial function took ${dialSW.elapsed}');
-  return chan;
+  return chan.timeout(opts.timeout);
 }
 
 Future<String> _searchMdns(String address) async {

--- a/lib/src/rpc/dial.dart
+++ b/lib/src/rpc/dial.dart
@@ -306,10 +306,12 @@ Future<ClientChannelBase> _dialWebRtc(String address, DialOptions options, Strin
           callUpdateRequest.uuid = uuid!;
         }
         final Stopwatch stopwatch = Stopwatch()..start();
+        final currUpdateCall = updateCalls++;
+        _logger.d('STATS: making call update $currUpdateCall to the signaling server');
         await signalingClient.callUpdate(callUpdateRequest);
         stopwatch.stop();
+        _logger.d('STATS: call update $currUpdateCall took ${stopwatch.elapsed}');
         callUpdateDuration += stopwatch.elapsed;
-        updateCalls++;
       } catch (error, st) {
         _logger.e('Update ICECandidate error', error: error, stackTrace: st);
       }

--- a/lib/src/rpc/dial.dart
+++ b/lib/src/rpc/dial.dart
@@ -200,8 +200,8 @@ Future<ClientChannelBase> _dialDirectGrpc(String address, DialOptions options, S
   return _authenticatedChannel(address, options, sessionCallback);
 }
 
-Future _logConnectionStats(Stopwatch webrtcDialSW, RTCPeerConnection peerConnection, int updateCalls,
-  Duration totalCallUpdateDuration, maxCallUpdateDuration) async {
+Future _logConnectionStats(Stopwatch webrtcDialSW, RTCPeerConnection peerConnection, int updateCalls, Duration totalCallUpdateDuration,
+    maxCallUpdateDuration) async {
   webrtcDialSW.stop();
   _logger.d('STATS: all ICE candidates gathered in ${webrtcDialSW.elapsed}');
   _logger.d('STATS: $updateCalls call updates to the signaling server were made');
@@ -326,8 +326,7 @@ Future<ClientChannelBase> _dialWebRtc(String address, DialOptions options, Strin
       // If all update calls have finished, report stats now. Otherwise, rely
       // on `onIceCandidate` callback below to report them.
       if (updateCalls == updateCallsFinished) {
-        await _logConnectionStats(webrtcDialSW, peerConnection, updateCalls,
-          totalCallUpdateDuration, maxCallUpdateDuration);
+        await _logConnectionStats(webrtcDialSW, peerConnection, updateCalls, totalCallUpdateDuration, maxCallUpdateDuration);
       }
     }
   };
@@ -373,8 +372,7 @@ Future<ClientChannelBase> _dialWebRtc(String address, DialOptions options, Strin
         // If ICE connection state has reached 'completed' and we have finished
         // all tracked updateCalls, report stats.
         if (iceConnectionCompleted && updateCalls == updateCallsFinished) {
-          await _logConnectionStats(webrtcDialSW, peerConnection, updateCalls,
-            totalCallUpdateDuration, maxCallUpdateDuration);
+          await _logConnectionStats(webrtcDialSW, peerConnection, updateCalls, totalCallUpdateDuration, maxCallUpdateDuration);
         }
       } catch (error, st) {
         _logger.e('Update ICECandidate error', error: error, stackTrace: st);


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-6515

Adds a `timeout` field to `DialOptions` that defaults to 10s. Adds a few basic metrics to dialing collected through debug logs.

mDNS does not seem to work well with the flutter SDK, so I disabled it in testing. Note that mDNS is also disabled in the RC app, too, as its apparent advantage in "limited connectivity" situations is not really relevant with a phone, as phones are usually operating with _some_ kind of network connection.

Here are some statistics I collected with the new instrumentation that led me to choose a 10s default dial timeout (about 10x "ICE connected" times across different subnets). These statistics are collected across 100 runs in both "Situation"s.

| Relevant Log | **Metric**        | Same Subnet | Different Subnet |
|--------------|-----------------------------|-------------|------------------|
|[link](https://github.com/viamrobotics/viam-flutter-sdk/pull/188/files#diff-31dfaef2a1da995ce2324bd2cb5060feb2701a103e3c48640488b10acc2b894bR152)| Dial function               | 0.003s      | 0.006s           |
|[link](https://github.com/viamrobotics/viam-flutter-sdk/pull/188/files#diff-31dfaef2a1da995ce2324bd2cb5060feb2701a103e3c48640488b10acc2b894bR320)| ICE connected                 | 0.976s      | 1.170s           |
|[link](https://github.com/viamrobotics/viam-flutter-sdk/pull/188/files#diff-31dfaef2a1da995ce2324bd2cb5060feb2701a103e3c48640488b10acc2b894bR206)| ICE completed                | 1.144s      | 16.574s           |
|[link](https://github.com/viamrobotics/viam-flutter-sdk/pull/188/files#diff-31dfaef2a1da995ce2324bd2cb5060feb2701a103e3c48640488b10acc2b894bR210)| Average call update time | 0.161s |  0.150s |
|[link](https://github.com/viamrobotics/viam-flutter-sdk/pull/188/files#diff-31dfaef2a1da995ce2324bd2cb5060feb2701a103e3c48640488b10acc2b894bR211)| Max call update time | 0.171s |  0.175s |
|[link](https://github.com/viamrobotics/viam-flutter-sdk/pull/188/files#diff-31dfaef2a1da995ce2324bd2cb5060feb2701a103e3c48640488b10acc2b894bR207)| Number of call updates | 8.000 |  8.000 |
|[link](https://github.com/viamrobotics/viam-flutter-sdk/pull/188/files#diff-31dfaef2a1da995ce2324bd2cb5060feb2701a103e3c48640488b10acc2b894bR547)| Auth                        | 0.176s      | 0.196s           |
|[link](https://github.com/viamrobotics/viam-flutter-sdk/pull/188/files#diff-31dfaef2a1da995ce2324bd2cb5060feb2701a103e3c48640488b10acc2b894bR262)| Signaling server connection | 0.177s      | 0.198s           |
|[link](https://github.com/viamrobotics/viam-flutter-sdk/pull/188/files#diff-31dfaef2a1da995ce2324bd2cb5060feb2701a103e3c48640488b10acc2b894bR303)| Peer connection creation    | 0.106s      | 0.069s           |

cc @dgottlieb , @maximpertsov , @ale7714 