### PR TITLE
remove intl dependency

### DIFF
--- a/lib/widgets/refreshable_data_table.dart
+++ b/lib/widgets/refreshable_data_table.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 import 'button.dart';
 
@@ -80,7 +79,7 @@ class _ViamRefreshableDataTableState extends State<ViamRefreshableDataTable> {
   }
 
   String formattedDate(DateTime date) {
-    return DateFormat('yyyy-MM-dd HH:mm:ss:SS').format(date);
+    return '${date.year}-${date.month}-${date.day} ${date.hour}:${date.minute}:${date.second}:${date.millisecond}';
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   fixnum: ^1.1.0
   flutter_joystick: ^0.0.3
   collection: ^1.17.1
-  intl: ^0.19.0
   async: ^2.11.0
   bonsoir: ^5.1.8
 


### PR DESCRIPTION
opened up an old project and had a conflict with this package, realized there is no reason we need it in the SDK itself, was only used for one helper function.

widget still looks good

![Screenshot 2024-04-12 at 11 08 41 AM](https://github.com/viamrobotics/viam-flutter-sdk/assets/22106496/f485df7a-d9fd-4ce2-9baa-21d905bfe756)

