### PR TITLE
RSDK-7376 Add more logs to dial

### DIFF
--- a/lib/src/rpc/dial.dart
+++ b/lib/src/rpc/dial.dart
@@ -346,6 +346,8 @@ Future<ClientChannelBase> _dialWebRtc(String address, DialOptions options, Strin
         return;
       }
 
+      _logger.d('STATS: candidate ${candidate.candidate} gathered');
+
       try {
         final candidateProto = ICECandidate();
         if (candidate.candidate != null) {
@@ -458,6 +460,7 @@ Future<ClientChannelBase> _dialWebRtc(String address, DialOptions options, Strin
         response.update.candidate.sdpmLineIndex,
       );
       try {
+        _logger.d('STATS: adding remote ICE candidate of ${iceCandidate.candidate}');
         await peerConnection.addCandidate(iceCandidate);
       } catch (error, st) {
         _logger.e('Add candidate error', error: error, stackTrace: st);


### PR DESCRIPTION
[RSDK-7376](https://viam.atlassian.net/browse/RSDK-7376)

Adds a couple more logs to dial code to indicate when local ICE candidates are generated and when remote ICE candidates are received from the signaling server (timestamps are already included in logs). Slight WIP, as I'd like to find a way to turn on verbose WebRTC logging, as well.

[RSDK-7376]: https://viam.atlassian.net/browse/RSDK-7376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ