### PR TITLE
RSDK-6665 - add getCloudMetadata client method

### DIFF
--- a/lib/src/robot/client.dart
+++ b/lib/src/robot/client.dart
@@ -14,6 +14,7 @@ import '../resource/registry.dart';
 import '../rpc/dial.dart';
 import '../rpc/web_rtc/web_rtc_client.dart';
 
+typedef CloudMetadata = GetCloudMetadataResponse;
 Logger _logger = Logger();
 
 /// The options that define the behavior of the [RobotClient].
@@ -226,5 +227,9 @@ class RobotClient {
   /// Get a WebRTC stream client with the given name
   StreamClient getStream(String name) {
     return _streamManager.getStreamClient(name);
+  }
+
+  Future<CloudMetadata> getCloudMetadata() async {
+    return await _client.getCloudMetadata(GetCloudMetadataRequest());
   }
 }


### PR DESCRIPTION
Note to reviewers: we currently have no testing set up for a robot client. It seems that adding some would necessitate either changing the `RobotClient` type to add new constructors, or a bit of digging/fiddling. I imagine this is why we didn't add tests in the past.

Given how trivial this method is to implement, I opted to just add it and continue to punt on the testing question. Happy to discuss if there's disagreement.