### PR TITLE
`viam_example_app` has syntax's errors

### DIFF
--- a/example/viam_example_app/lib/location_screen.dart
+++ b/example/viam_example_app/lib/location_screen.dart
@@ -40,7 +40,7 @@ class _LocationScreenState extends State<LocationScreen> {
   Future<void> _initState() async {
     // Using the authenticated [Viam] the received as a parameter,
     // we can obtain a list of robots within this location.
-    final robots = await widget._viam.appClient.listRobots(widget.location);
+    final robots = await widget._viam.appClient.listRobots(widget.location.id);
     setState(() {
       // Once we have the list of robots, we can set the state.
       this.robots = robots;

--- a/example/viam_example_app/lib/organization_screen.dart
+++ b/example/viam_example_app/lib/organization_screen.dart
@@ -44,7 +44,7 @@ class _OrganizationScreenState extends State<OrganizationScreen> {
   Future<void> _initState() async {
     // Using the authenticated [Viam] the received as a parameter,
     // we can obtain a list of locations within this organization.
-    final locations = await widget._viam.appClient.listLocations(widget.organization);
+    final locations = await widget._viam.appClient.listLocations(widget.organization.id);
     setState(() {
       // Once we have the list of locations, we can set the state.
       this.locations = locations;


### PR DESCRIPTION
I'm unsure if there is a code of conduct or a PR template for PRs but I'll post it as is.

I wanted to look at the SDK and I found the example app, most likely not up-to-date with the latest changes in the SDK.
So, here is a possible fix for it.