### PR TITLE
RSDK-8304 - send version metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,9 @@ jobs:
         uses: andymckay/cancel-action@0.2
         if: steps.release_exists.outputs.id != ''
 
+      - name: Bump Version Metadata
+        run: sed -i -e "s/sdkVersion = 'v[0-9]*\.[0-9]*\.[0-9]*'/sdkVersion = 'v${{ steps.which_version.outputs.version }}'" > lib/src/utils.dart
+
       - name: "Generate release changelog"
         uses: heinrichreimer/github-changelog-generator-action@v2.3
         with:

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -26,6 +26,9 @@ jobs:
 
       - run: make setup
 
+      - name: Update Proto Tag
+        run: sed -i -e "s/apiTag = 'v[0-9]*\.[0-9]*\.[0-9]*'/apiTag = '${{ github.event.client_payload.tag }}'" > lib/src/utils.dart
+
       - name: Generate buf
         run: make buf
         env:
@@ -33,9 +36,6 @@ jobs:
 
       - name: Format
         run: make format
-
-      - name: Update Proto Tag
-        run: sed -i -e "s/apiTag = 'v[0-9]*\.[0-9]*\.[0-9]*'/api_tag = '${{ github.event.client_payload.tag }}'" > lib/src/utils.dart
 
       - name: Add + Commit + Open PR
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Format
         run: make format
 
+      - name: Update Proto Tag
+        run: sed -i -e "s/apiTag = 'v[0-9]*\.[0-9]*\.[0-9]*'/api_tag = '${{ github.event.client_payload.tag }}'" > lib/src/utils.dart
+
       - name: Add + Commit + Open PR
         uses: peter-evans/create-pull-request@v5
         with:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 
 buf: buf.yaml buf.gen.yaml
 	rm -rf lib/src/gen
-	$(eval API_VERSION := $(shell grep 'apiTag' lib/src/utils.dart | awk -F '"' '{print $$2}'))
+	$(eval API_VERSION := $(shell grep 'const String apiTag' lib/src/utils.dart | awk -F "'" '{print $$2}'))
 	PATH=$(PATH_WITH_TOOLS) buf generate buf.build/viamrobotics/goutils
 	PATH=$(PATH_WITH_TOOLS) buf generate buf.build/viamrobotics/api:${API_VERSION}
 	PATH=$(PATH_WITH_TOOLS) buf generate buf.build/googleapis/googleapis

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,9 @@ endif
 
 buf: buf.yaml buf.gen.yaml
 	rm -rf lib/src/gen
+	$(eval API_VERSION := $(shell grep 'apiTag' lib/src/utils.dart | awk -F '"' '{print $$2}'))
 	PATH=$(PATH_WITH_TOOLS) buf generate buf.build/viamrobotics/goutils
-	PATH=$(PATH_WITH_TOOLS) buf generate buf.build/viamrobotics/api
+	PATH=$(PATH_WITH_TOOLS) buf generate buf.build/viamrobotics/api:${API_VERSION}
 	PATH=$(PATH_WITH_TOOLS) buf generate buf.build/googleapis/googleapis
 	PATH=$(PATH_WITH_TOOLS) buf generate buf.build/protocolbuffers/wellknowntypes --path google/protobuf/any.proto
 	PATH=$(PATH_WITH_TOOLS) buf generate buf.build/protocolbuffers/wellknowntypes --path google/protobuf/duration.proto

--- a/lib/src/rpc/dial.dart
+++ b/lib/src/rpc/dial.dart
@@ -586,6 +586,7 @@ class AuthenticatedChannel extends ViamGrpcOrGrpcWebChannel {
     }
 
     options = options.mergedWith(CallOptions(metadata: {'Authorization': 'Bearer $accessToken'}));
+    options = options.mergedWith(CallOptions(metadata: {'viam_client': getVersionMetadata()}));
     return super.createCall(method, requests, options);
   }
 }

--- a/lib/src/rpc/web_rtc/web_rtc_client.dart
+++ b/lib/src/rpc/web_rtc/web_rtc_client.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:grpc/grpc.dart';
 import 'package:grpc/grpc_connection_interface.dart';
+import 'package:viam_sdk/src/utils.dart';
 
 import '../../robot/sessions_client.dart';
 import 'web_rtc_client_connection.dart';
@@ -31,6 +32,7 @@ class WebRtcClientChannel extends ClientChannelBase {
     if (!SessionsClient.unallowedMethods.contains(method.path)) {
       options = options.mergedWith(CallOptions(metadata: {SessionsClient.sessionMetadataKey: _sessionId()}));
     }
+    options = options.mergedWith(CallOptions(metadata: {'viam_client': getVersionMetadata()}));
     return super.createCall(method, requests, options);
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,3 +1,4 @@
+import 'package:format/format.dart';
 import 'package:grpc/grpc.dart';
 import 'package:logger/logger.dart';
 
@@ -81,4 +82,10 @@ extension MapStructUtils on Map<String, dynamic> {
   Value toValue() {
     return Value()..structValue = toStruct();
   }
+}
+
+String getVersionMetadata() {
+  const String sdkVersion = 'v0.0.18';
+  const String apiTag = 'v0.1.328';
+  return format('flutter;{};{}', sdkVersion, apiTag);
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,4 +1,3 @@
-import 'package:format/format.dart';
 import 'package:grpc/grpc.dart';
 import 'package:logger/logger.dart';
 
@@ -87,5 +86,5 @@ extension MapStructUtils on Map<String, dynamic> {
 String getVersionMetadata() {
   const String sdkVersion = 'v0.0.18';
   const String apiTag = 'v0.1.328';
-  return format('flutter;{};{}', sdkVersion, apiTag);
+  return 'flutter;$sdkVersion;$apiTag';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   collection: ^1.17.1
   async: ^2.11.0
   bonsoir: ^5.1.8
+  format: ^1.5.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
   collection: ^1.17.1
   async: ^2.11.0
   bonsoir: ^5.1.8
-  format: ^1.5.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
How it works:
 - `update-protos.yml` updates the `apiTag` value in the `getVersionMetadata` function
 - `release.yml` updates the `sdkVersion` value in the `getVersionMetadata` function
 - channels update their options to set `viam_client` equal to the output of `getVersionMetadata`

Note that this is a bit of a bummer because we're storing the SDK version in two places (`pubspec.yml` and `utils.dart`). I spent a good amount of time trying to find some alternative whereby we'd get the version info out of `pubspec.yml` instead. The potential solutions and (seemingly intractable) problems I encountered were:
 - you can't read data out of `pubspec.yml` directly in a synchronous way, which means that reading `pubspec.yml` data would require polluting our API with async, which would be a significant breaking change and open tons of new cans of worms.
 - Though it's not recommended, you _can_ just open a file synchronously (i.e., instead of saying "give me pubspec data" we could say "open the file found at `pubspec.yml` and convert it into a map that I can parse). This seemed promising and tests passed, but the problem I found was the absolute path to `pubspec.yml` can't be reliably assumed, and setting a relative path meant the file couldn't always be found (it was found successfully for a unit test, but not by the `flutter-rc-app` running from a sibling directory). So, this approach was too fragile to work.
 - Technically, you can still force an async function in dart to run to completion and block synchronously, meaning we _could_ get the ask for data from the `pubspec.yml` as per the first option above. But, the function to do so is deprecated, will be removed soon, and its use is strongly discouraged. So that approach is neither future proof nor idiomatic.

Given the above, I opted for the simple and consistent, but sadly duplicative, approach that we wound up with here. 

![Screenshot 2024-08-01 at 09 27 42](https://github.com/user-attachments/assets/56b86985-89bf-44f4-b287-edcc4f0dd879)
