### PR TITLE
RSDK-8607 - fix timeout generation bug

### DIFF
--- a/lib/src/rpc/web_rtc/web_rtc_client_connection.dart
+++ b/lib/src/rpc/web_rtc/web_rtc_client_connection.dart
@@ -42,9 +42,7 @@ class WebRtcClientConnection extends ClientConnection {
   }) {
     final stream = grpc.Stream()..id = Int64(id++);
     final grpMetadata = grpc.Metadata()..md.addAll(metadata.map((key, value) => MapEntry(key, grpc.Strings()..values.addAll([value]))));
-    final grpc_duration.Duration? grpcTimeout = timeout != null
-        ? durationToProto(timeout)
-        : null;
+    final grpc_duration.Duration? grpcTimeout = timeout != null ? durationToProto(timeout) : null;
     final headers = grpc.RequestHeaders()
       ..method = path
       ..metadata = grpMetadata;

--- a/lib/src/rpc/web_rtc/web_rtc_client_connection.dart
+++ b/lib/src/rpc/web_rtc/web_rtc_client_connection.dart
@@ -5,6 +5,7 @@ import 'package:fixnum/fixnum.dart';
 import 'package:grpc/grpc.dart';
 import 'package:grpc/grpc_connection_interface.dart';
 
+import '../../utils.dart';
 import '../../gen/google/protobuf/duration.pb.dart' as grpc_duration;
 import '../../gen/proto/rpc/webrtc/v1/grpc.pb.dart' as grpc;
 import 'web_rtc_client.dart';
@@ -42,11 +43,8 @@ class WebRtcClientConnection extends ClientConnection {
     final stream = grpc.Stream()..id = Int64(id++);
     final grpMetadata = grpc.Metadata()..md.addAll(metadata.map((key, value) => MapEntry(key, grpc.Strings()..values.addAll([value]))));
     final grpc_duration.Duration? grpcTimeout = timeout != null
-        ? (grpc_duration.Duration()
-          ..seconds = Int64(timeout.inSeconds)
-          ..nanos = timeout.inMicroseconds * 1000)
+        ? durationToProto(timeout)
         : null;
-    // final headers = grpc.RequestHeaders(method: path, metadata: grpMetadata, timeout: grpcTimeout);
     final headers = grpc.RequestHeaders()
       ..method = path
       ..metadata = grpMetadata;

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,7 +1,9 @@
+import 'package:fixnum/fixnum.dart';
 import 'package:grpc/grpc.dart';
 import 'package:logger/logger.dart';
 
 import 'gen/google/protobuf/struct.pb.dart';
+import 'gen/google/protobuf/duration.pb.dart' as grpc_duration;
 
 final _logger = Logger();
 
@@ -81,6 +83,13 @@ extension MapStructUtils on Map<String, dynamic> {
   Value toValue() {
     return Value()..structValue = toStruct();
   }
+}
+
+grpc_duration.Duration durationToProto(Duration duration) {
+  final micros = duration.inMicroseconds % Duration.microsecondsPerSecond;
+  return grpc_duration.Duration()
+    ..seconds = Int64(duration.inSeconds)
+    ..nanos = micros * 1000;
 }
 
 String getVersionMetadata() {

--- a/test/unit_test/utils/utils_test.dart
+++ b/test/unit_test/utils/utils_test.dart
@@ -74,6 +74,27 @@ void main() {
       });
     });
 
+    test('durationToProto', () {
+      // check that a standard one second duration converts to proto successfully
+      const oneSecond = Duration(seconds: 1);
+      final oneSecondProto = durationToProto(oneSecond);
+      expect(oneSecondProto.seconds.toInt(), 1);
+      expect(oneSecondProto.nanos, 0);
+
+      // check that a > 2sec duration converts to proto successfully without causing an int
+      // overflow in nanos
+      const fiveSeconds = Duration(seconds: 5);
+      final fiveSecondProto = durationToProto(fiveSeconds);
+      expect(fiveSecondProto.seconds.toInt(), 5);
+      expect(fiveSecondProto.nanos, 0);
+
+      // check that a mixed "seconds and microseconds" Duration successfully converts to proto.
+      const mixed = Duration(seconds: 3, microseconds: 1234);
+      final mixedProto = durationToProto(mixed);
+      expect(mixedProto.seconds.toInt(), 3);
+      expect(mixedProto.nanos, 1234000);
+    });
+
     test('StructUtils toMap', () {
       final struct = Struct()..fields.addAll({'foo': Value()..stringValue = 'bar'});
       expect(struct.toMap(), {'foo': 'bar'});


### PR DESCRIPTION
Fixes a bug whereby we were doubling timeout durations by putting the full value in both the `seconds` and `nanos` fields, which incidentally meant that we were getting an int overflow error when trying to pass a timeout of ~2sec or greater.