### PR TITLE
RSDK-8812: Add frame_rate to flutter sdk

### DIFF
--- a/lib/src/components/camera/service.dart
+++ b/lib/src/components/camera/service.dart
@@ -51,10 +51,14 @@ class CameraService extends CameraServiceBase {
   Future<GetPropertiesResponse> getProperties(ServiceCall call, GetPropertiesRequest request) async {
     final camera = _fromManager(request.name);
     final properties = await camera.properties();
-    return GetPropertiesResponse()
+    final response = GetPropertiesResponse()
       ..supportsPcd = properties.supportsPcd
       ..intrinsicParameters = properties.intrinsicParameters
       ..distortionParameters = properties.distortionParameters;
+      if (properties.frameRate != 0) {
+          response.frameRate = properties.frameRate;
+      }
+      return response;
   }
 
   @override

--- a/lib/src/components/camera/service.dart
+++ b/lib/src/components/camera/service.dart
@@ -51,14 +51,7 @@ class CameraService extends CameraServiceBase {
   Future<GetPropertiesResponse> getProperties(ServiceCall call, GetPropertiesRequest request) async {
     final camera = _fromManager(request.name);
     final properties = await camera.properties();
-    final response = GetPropertiesResponse()
-      ..supportsPcd = properties.supportsPcd
-      ..intrinsicParameters = properties.intrinsicParameters
-      ..distortionParameters = properties.distortionParameters;
-    if (properties.frameRate != 0) {
-      response.frameRate = properties.frameRate;
-    }
-    return response;
+    return properties;
   }
 
   @override

--- a/lib/src/components/camera/service.dart
+++ b/lib/src/components/camera/service.dart
@@ -55,10 +55,10 @@ class CameraService extends CameraServiceBase {
       ..supportsPcd = properties.supportsPcd
       ..intrinsicParameters = properties.intrinsicParameters
       ..distortionParameters = properties.distortionParameters;
-      if (properties.frameRate != 0) {
-          response.frameRate = properties.frameRate;
-      }
-      return response;
+    if (properties.frameRate != 0) {
+      response.frameRate = properties.frameRate;
+    }
+    return response;
   }
 
   @override

--- a/test/unit_test/components/camera_test.dart
+++ b/test/unit_test/components/camera_test.dart
@@ -45,10 +45,10 @@ class FakeCamera extends Camera {
       ..supportsPcd = true
       ..intrinsicParameters = (IntrinsicParameters()..widthPx = 10)
       ..distortionParameters = (DistortionParameters()..model = 'test');
-      if(setFrameRate){
-        properties.frameRate = 10.0;
-      }
-      return properties;
+    if (setFrameRate) {
+      properties.frameRate = 10.0;
+    }
+    return properties;
   }
 }
 
@@ -60,7 +60,7 @@ void main() {
 
     setUp(() {
       camera = FakeCamera(name);
-      frameRateCamera = FakeCamera(name, setFrameRate : true);
+      frameRateCamera = FakeCamera(name, setFrameRate: true);
     });
 
     test('image', () async {
@@ -102,7 +102,6 @@ void main() {
       final resp = await camera.doCommand(cmd);
       expect(resp['command'], cmd);
     });
-
   });
 
   group('Camera RPC Tests', () {
@@ -113,7 +112,7 @@ void main() {
     const String name = 'camera';
 
     setUp(() async {
-      camera = FakeCamera(name, setFrameRate : false);
+      camera = FakeCamera(name, setFrameRate: false);
       final port = generateTestingPortFromName(name);
       final manager = ResourceManager();
       manager.register(Camera.getResourceName(name), camera);
@@ -180,7 +179,6 @@ void main() {
           ..command = cmd.toStruct());
         expect(resp.result.toMap(), {'command': cmd});
       });
-      
     });
     group('Camera Client Tests', () {
       test('image', () async {
@@ -219,7 +217,6 @@ void main() {
         final resp = await client.doCommand(cmd);
         expect(resp['command'], cmd);
       });
-
     });
   });
 
@@ -231,7 +228,7 @@ void main() {
     const String name = 'camera';
 
     setUp(() async {
-      camera = FakeCamera(name, setFrameRate : true);
+      camera = FakeCamera(name, setFrameRate: true);
       final port = generateTestingPortFromName(name);
       final manager = ResourceManager();
       manager.register(Camera.getResourceName(name), camera);
@@ -265,5 +262,4 @@ void main() {
       });
     });
   });
-
 }

--- a/test/unit_test/components/camera_test.dart
+++ b/test/unit_test/components/camera_test.dart
@@ -43,7 +43,8 @@ class FakeCamera extends Camera {
     return CameraProperties()
       ..supportsPcd = true
       ..intrinsicParameters = (IntrinsicParameters()..widthPx = 10)
-      ..distortionParameters = (DistortionParameters()..model = 'test');
+      ..distortionParameters = (DistortionParameters()..model = 'test')
+      ..frameRate = 10.0;
   }
 }
 
@@ -80,6 +81,7 @@ void main() {
       final actual = await camera.properties();
       expect(actual.distortionParameters.model, 'test');
       expect(actual.intrinsicParameters.widthPx, 10);
+      expect(actual.frameRate, 10.0);
     });
 
     test('doCommand', () async {

--- a/test/unit_test/components/camera_test.dart
+++ b/test/unit_test/components/camera_test.dart
@@ -15,7 +15,7 @@ class FakeCamera extends Camera {
   String name;
   bool setFrameRate;
 
-  FakeCamera(this.name, {this.setFrameRate = true});
+  FakeCamera(this.name, {this.setFrameRate = false});
 
   @override
   Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) async {
@@ -59,7 +59,7 @@ void main() {
     late FakeCamera frameRateCamera;
 
     setUp(() {
-      camera = FakeCamera(name, setFrameRate : false);
+      camera = FakeCamera(name);
       frameRateCamera = FakeCamera(name, setFrameRate : true);
     });
 

--- a/test/unit_test/components/camera_test.dart
+++ b/test/unit_test/components/camera_test.dart
@@ -13,8 +13,9 @@ class FakeCamera extends Camera {
 
   @override
   String name;
+  bool setFrameRate;
 
-  FakeCamera(this.name);
+  FakeCamera(this.name, {this.setFrameRate = true});
 
   @override
   Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) async {
@@ -40,10 +41,14 @@ class FakeCamera extends Camera {
 
   @override
   Future<CameraProperties> properties() async {
-    return CameraProperties()
+    final properties = CameraProperties()
       ..supportsPcd = true
       ..intrinsicParameters = (IntrinsicParameters()..widthPx = 10)
       ..distortionParameters = (DistortionParameters()..model = 'test');
+      if(setFrameRate){
+        properties.frameRate = 10.0;
+      }
+      return properties;
   }
 }
 
@@ -51,9 +56,11 @@ void main() {
   group('Camera Tests', () {
     const String name = 'camera';
     late FakeCamera camera;
+    late FakeCamera frameRateCamera;
 
     setUp(() {
-      camera = FakeCamera(name);
+      camera = FakeCamera(name, setFrameRate : false);
+      frameRateCamera = FakeCamera(name, setFrameRate : true);
     });
 
     test('image', () async {
@@ -76,10 +83,18 @@ void main() {
       expect(actualPcd.raw, [0, 0, 0]);
     });
 
-    test('properties', () async {
+    test('properties without frame rate', () async {
       final actual = await camera.properties();
       expect(actual.distortionParameters.model, 'test');
       expect(actual.intrinsicParameters.widthPx, 10);
+      expect(actual.frameRate, 0);
+    });
+
+    test('properties with frame rate', () async {
+      final actual = await frameRateCamera.properties();
+      expect(actual.distortionParameters.model, 'test');
+      expect(actual.intrinsicParameters.widthPx, 10);
+      expect(actual.frameRate, 10.0);
     });
 
     test('doCommand', () async {
@@ -87,6 +102,7 @@ void main() {
       final resp = await camera.doCommand(cmd);
       expect(resp['command'], cmd);
     });
+
   });
 
   group('Camera RPC Tests', () {
@@ -97,7 +113,7 @@ void main() {
     const String name = 'camera';
 
     setUp(() async {
-      camera = FakeCamera(name);
+      camera = FakeCamera(name, setFrameRate : false);
       final port = generateTestingPortFromName(name);
       final manager = ResourceManager();
       manager.register(Camera.getResourceName(name), camera);
@@ -148,11 +164,12 @@ void main() {
         expect(actualPcd.pointCloud, [0, 0, 0]);
       });
 
-      test('properties', () async {
+      test('properties without frameRate', () async {
         final client = CameraServiceClient(channel);
         final actual = await client.getProperties(GetPropertiesRequest()..name = name);
         expect(actual.distortionParameters.model, 'test');
         expect(actual.intrinsicParameters.widthPx, 10);
+        expect(actual.frameRate, 0);
       });
 
       test('doCommand', () async {
@@ -163,6 +180,7 @@ void main() {
           ..command = cmd.toStruct());
         expect(resp.result.toMap(), {'command': cmd});
       });
+      
     });
     group('Camera Client Tests', () {
       test('image', () async {
@@ -187,11 +205,12 @@ void main() {
         expect(actualPcd.raw, [0, 0, 0]);
       });
 
-      test('properties', () async {
+      test('properties without frame rate', () async {
         final client = CameraClient(name, channel);
         final actual = await client.properties();
         expect(actual.distortionParameters.model, 'test');
         expect(actual.intrinsicParameters.widthPx, 10);
+        expect(actual.frameRate, 0.0);
       });
 
       test('doCommand', () async {
@@ -200,6 +219,51 @@ void main() {
         final resp = await client.doCommand(cmd);
         expect(resp['command'], cmd);
       });
+
     });
   });
+
+  group('Camera RPC Tests with frame rate', () {
+    late ClientChannel channel;
+    late FakeCamera camera;
+    late CameraService service;
+    late Server server;
+    const String name = 'camera';
+
+    setUp(() async {
+      camera = FakeCamera(name, setFrameRate : true);
+      final port = generateTestingPortFromName(name);
+      final manager = ResourceManager();
+      manager.register(Camera.getResourceName(name), camera);
+      service = CameraService(manager);
+      channel = ClientChannel('localhost', port: port, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
+      server = Server.create(services: [service]);
+      await server.serve(port: port);
+    });
+
+    tearDown(() async {
+      await channel.shutdown();
+      await server.shutdown();
+    });
+
+    group('Camera Service Tests', () {
+      test('properties with frameRate', () async {
+        final client = CameraServiceClient(channel);
+        final actual = await client.getProperties(GetPropertiesRequest()..name = name);
+        expect(actual.distortionParameters.model, 'test');
+        expect(actual.intrinsicParameters.widthPx, 10);
+        expect(actual.frameRate, 10.0);
+      });
+    });
+    group('Camera Client Tests', () {
+      test('properties with frameRate', () async {
+        final client = CameraClient(name, channel);
+        final actual = await client.properties();
+        expect(actual.distortionParameters.model, 'test');
+        expect(actual.intrinsicParameters.widthPx, 10);
+        expect(actual.frameRate, 10.0);
+      });
+    });
+  });
+
 }


### PR DESCRIPTION
- added support for `frame_rate` by returning it in getProperties in service.dart
- added a test in camera_test.dart to test for setting vs not setting `frame_rate`