### PR TITLE
Remove deprecated lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,8 +6,6 @@ linter:
     - avoid_catching_errors
     - avoid_dynamic_calls
     - avoid_field_initializers_in_const_classes
-    - avoid_returning_null
-    - avoid_returning_null_for_future
     - avoid_slow_async_io
     - avoid_type_to_string
     - avoid_void_async


### PR DESCRIPTION
These two lints have been deprecated. Removing.

> 'avoid_returning_null' was removed in Dart '3.3.0'
> Remove the reference to 'avoid_returning_null'.

> 'avoid_returning_null_for_future' was removed in Dart '3.3.0'
> Remove the reference to 'avoid_returning_null_for_future'.