### PR TITLE
[refactor] order imports & prefer local import

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -23,6 +23,8 @@ linter:
     - unnecessary_statements
     - unnecessary_await_in_return
     - prefer_final_locals
+    - directives_ordering
+    - prefer_relative_imports
 
 analyzer:
   errors:

--- a/lib/src/app/app.dart
+++ b/lib/src/app/app.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 
-import 'package:viam_sdk/protos/app/packages.dart';
-import 'package:viam_sdk/src/utils.dart';
-
+import '../../protos/app/packages.dart';
 import '../gen/app/v1/app.pbgrpc.dart';
 import '../gen/common/v1/common.pb.dart';
+import '../utils.dart';
 import 'permissions.dart';
 
 typedef RobotPartLogPage = GetRobotPartLogsResponse;

--- a/lib/src/app/billing.dart
+++ b/lib/src/app/billing.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:viam_sdk/protos/app/billing.dart';
+import '../../protos/app/billing.dart';
 
 /// gRPC client for connecting to Viam's Billing Service
 ///

--- a/lib/src/app/data.dart
+++ b/lib/src/app/data.dart
@@ -4,15 +4,15 @@ import 'dart:typed_data';
 import 'package:async/async.dart';
 import 'package:collection/collection.dart';
 import 'package:fixnum/fixnum.dart';
-import 'package:viam_sdk/protos/app/data.dart';
-import 'package:viam_sdk/src/gen/google/protobuf/any.pb.dart';
-import 'package:viam_sdk/src/utils.dart';
 
+import '../../protos/app/data.dart';
 import '../gen/app/data/v1/data.pbgrpc.dart';
 import '../gen/app/dataset/v1/dataset.pbgrpc.dart';
 import '../gen/app/datasync/v1/data_sync.pbgrpc.dart' hide CaptureInterval;
+import '../gen/google/protobuf/any.pb.dart';
 import '../gen/google/protobuf/timestamp.pb.dart';
 import '../media/image.dart';
+import '../utils.dart';
 
 /// {@category Viam SDK}
 typedef DatabaseConnection = GetDatabaseConnectionResponse;

--- a/lib/src/app/ml_training.dart
+++ b/lib/src/app/ml_training.dart
@@ -1,4 +1,4 @@
-import 'package:viam_sdk/protos/app/ml_training.dart';
+import '../../protos/app/ml_training.dart';
 
 /// gRPC client used for working with ML training jobs.
 ///

--- a/lib/src/app/robot.dart
+++ b/lib/src/app/robot.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:logger/logger.dart';
-import 'package:viam_sdk/src/gen/google/protobuf/timestamp.pb.dart';
 
 import '../gen/app/v1/robot.pbgrpc.dart';
 import '../gen/common/v1/common.pb.dart';
+import '../gen/google/protobuf/timestamp.pb.dart';
 
 /// {@category Viam SDK}
 /// gRPC client for connecting to app's RobotService.

--- a/lib/src/resource/manager.dart
+++ b/lib/src/resource/manager.dart
@@ -1,5 +1,4 @@
-import 'package:viam_sdk/src/gen/common/v1/common.pb.dart';
-
+import '../gen/common/v1/common.pb.dart';
 import 'base.dart';
 
 /// [ResourceManager] manages the state of all currently available resources of a robot

--- a/lib/src/robot/client.dart
+++ b/lib/src/robot/client.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:grpc/grpc_connection_interface.dart';
 import 'package:logger/logger.dart';
-import 'package:viam_sdk/src/robot/sessions_client.dart';
 
 import '../gen/common/v1/common.pb.dart';
 import '../gen/robot/v1/robot.pbgrpc.dart';
@@ -13,6 +12,7 @@ import '../resource/manager.dart';
 import '../resource/registry.dart';
 import '../rpc/dial.dart';
 import '../rpc/web_rtc/web_rtc_client.dart';
+import 'sessions_client.dart';
 
 /// {@category Viam SDK}
 typedef CloudMetadata = GetCloudMetadataResponse;

--- a/lib/src/rpc/web_rtc/web_rtc_client.dart
+++ b/lib/src/rpc/web_rtc/web_rtc_client.dart
@@ -1,9 +1,9 @@
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:grpc/grpc.dart';
 import 'package:grpc/grpc_connection_interface.dart';
-import 'package:viam_sdk/src/utils.dart';
 
 import '../../robot/sessions_client.dart';
+import '../../utils.dart';
 import 'web_rtc_client_connection.dart';
 
 class WebRtcClientChannel extends ClientChannelBase {

--- a/lib/src/rpc/web_rtc/web_rtc_client_connection.dart
+++ b/lib/src/rpc/web_rtc/web_rtc_client_connection.dart
@@ -5,9 +5,9 @@ import 'package:fixnum/fixnum.dart';
 import 'package:grpc/grpc.dart';
 import 'package:grpc/grpc_connection_interface.dart';
 
-import '../../utils.dart';
 import '../../gen/google/protobuf/duration.pb.dart' as grpc_duration;
 import '../../gen/proto/rpc/webrtc/v1/grpc.pb.dart' as grpc;
+import '../../utils.dart';
 import 'web_rtc_client.dart';
 import 'web_rtc_transport_stream.dart';
 

--- a/lib/src/viam_sdk_impl.dart
+++ b/lib/src/viam_sdk_impl.dart
@@ -1,11 +1,11 @@
 import 'package:grpc/grpc.dart';
 import 'package:grpc/grpc_connection_interface.dart';
-import 'package:viam_sdk/protos/app/data_sync.dart';
-import 'package:viam_sdk/protos/app/dataset.dart';
 
 import '../protos/app/app.dart';
 import '../protos/app/billing.dart';
 import '../protos/app/data.dart';
+import '../protos/app/data_sync.dart';
+import '../protos/app/dataset.dart';
 import '../protos/app/robot.dart';
 import '../protos/provisioning/provisioning.dart';
 import './app/app.dart';

--- a/lib/widgets/camera_stream.dart
+++ b/lib/widgets/camera_stream.dart
@@ -3,7 +3,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:logger/logger.dart';
-import 'package:viam_sdk/viam_sdk.dart';
+
+import '../viam_sdk.dart';
 
 /// A widget to display a WebRTC stream from a [Camera].
 class ViamCameraStreamView extends StatefulWidget {

--- a/lib/widgets/joystick.dart
+++ b/lib/widgets/joystick.dart
@@ -2,7 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_joystick/flutter_joystick.dart';
-import 'package:viam_sdk/viam_sdk.dart';
+
+import '../viam_sdk.dart';
 
 /// A [Joystick] to control a specific [Base]
 class ViamBaseJoystick extends StatefulWidget {

--- a/lib/widgets/multi_camera_stream.dart
+++ b/lib/widgets/multi_camera_stream.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:viam_sdk/viam_sdk.dart';
 
+import '../viam_sdk.dart';
 import './camera_stream.dart';
 
 /// A widget to display a WebRTC stream from a [Camera], and a dropdown to select which camera to view.

--- a/lib/widgets/resources/arm.dart
+++ b/lib/widgets/resources/arm.dart
@@ -1,7 +1,8 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:viam_sdk/viam_sdk.dart';
-import 'package:viam_sdk/widgets.dart';
+
+import '../../viam_sdk.dart';
+import '../../widgets.dart';
 
 /// A widget to control an [Arm].
 class ViamArmWidget extends StatefulWidget {

--- a/lib/widgets/resources/base.dart
+++ b/lib/widgets/resources/base.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:viam_sdk/viam_sdk.dart';
 
+import '../../viam_sdk.dart';
 import '../joystick.dart';
 import '../multi_camera_stream.dart';
 

--- a/lib/widgets/resources/board.dart
+++ b/lib/widgets/resources/board.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:viam_sdk/viam_sdk.dart';
 
+import '../../viam_sdk.dart';
 import '../button.dart';
 
 /// A widget to control a [Board].

--- a/lib/widgets/resources/gripper.dart
+++ b/lib/widgets/resources/gripper.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/widgets.dart';
-import 'package:viam_sdk/viam_sdk.dart';
 
+import '../../viam_sdk.dart';
 import '../button.dart';
 import '../multi_camera_stream.dart';
 

--- a/lib/widgets/resources/motor.dart
+++ b/lib/widgets/resources/motor.dart
@@ -1,7 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:viam_sdk/viam_sdk.dart';
+
+import '../../viam_sdk.dart';
 
 /// A widget to control a [Motor].
 ///

--- a/lib/widgets/resources/sensor.dart
+++ b/lib/widgets/resources/sensor.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:viam_sdk/viam_sdk.dart';
-import 'package:viam_sdk/widgets/refreshable_data_table.dart';
+
+import '../../viam_sdk.dart';
+import '../refreshable_data_table.dart';
 
 /// A widget to display data from a [Sensor].
 ///

--- a/lib/widgets/resources/servo.dart
+++ b/lib/widgets/resources/servo.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:viam_sdk/viam_sdk.dart';
-import 'package:viam_sdk/widgets.dart';
+
+import '../../viam_sdk.dart';
+import '../../widgets.dart';
 
 class ViamServoWidget extends StatefulWidget {
   final Servo servo;

--- a/test/unit_test/components/sensor_test.dart
+++ b/test/unit_test/components/sensor_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:grpc/grpc.dart';
 import 'package:viam_sdk/src/components/sensor/service.dart';
-import 'package:viam_sdk/src/gen/component/sensor/v1/sensor.pbgrpc.dart';
 import 'package:viam_sdk/src/gen/common/v1/common.pb.dart';
+import 'package:viam_sdk/src/gen/component/sensor/v1/sensor.pbgrpc.dart';
 import 'package:viam_sdk/src/resource/manager.dart';
 import 'package:viam_sdk/src/utils.dart';
 import 'package:viam_sdk/viam_sdk.dart';


### PR DESCRIPTION
I am proposing adding 2 new lint rules to our dart codebases.

https://dart.dev/tools/linter-rules/prefer_relative_imports

https://dart.dev/tools/linter-rules/directives_ordering

### ordering directives:

This lint will enforce the following order in the imports
1. dart imports
2. flutter package imports
3. relative emports
4. exports and parts

As well as enforcing alphabetical order inside those sections.

### prefer relative imports:
will enforce using relative import for any files imported from lib/ - which paired with order_directives will ensure local imports are always listed after external imports.

---
This PR does not make any functional changes, just re organizes imports and adds lint rules to support the pattern moving forward.

This is the same pattern we are following for our mobile app repos, the consistency across all dart repos would be beneficial.