### PR TITLE
Do not send empty session id when sessions disabled

### DIFF
--- a/lib/src/rpc/web_rtc/web_rtc_client.dart
+++ b/lib/src/rpc/web_rtc/web_rtc_client.dart
@@ -29,8 +29,11 @@ class WebRtcClientChannel extends ClientChannelBase {
 
   @override
   ClientCall<Q, R> createCall<Q, R>(ClientMethod<Q, R> method, Stream<Q> requests, CallOptions options) {
-    if (!SessionsClient.unallowedMethods.contains(method.path)) {
-      options = options.mergedWith(CallOptions(metadata: {SessionsClient.sessionMetadataKey: _sessionId()}));
+    final sessionMetadata = _sessionId();
+
+    // _sessionId will return '' empty if sessions are not enabled.
+    if (sessionMetadata.isNotEmpty && !SessionsClient.unallowedMethods.contains(method.path)) {
+      options = options.mergedWith(CallOptions(metadata: {SessionsClient.sessionMetadataKey: sessionMetadata}));
     }
     options = options.mergedWith(CallOptions(metadata: {'viam_client': getVersionMetadata()}));
     return super.createCall(method, requests, options);


### PR DESCRIPTION
before this change If I disabled sessions in dialOptions I would get an error whenever making a call to a robot.

```
gRPC Error (code: 2, codeName: UNKNOWN, message: invalid UUID length: 0, details: [], rawResponse: null, trailers: {})
```