### PR TITLE
RSDK-9180: Change TabularDataBySQL/MQL return type to raw BSON in Flutter SDK

### DIFF
--- a/lib/src/app/data.dart
+++ b/lib/src/app/data.dart
@@ -89,7 +89,6 @@ class DataClient {
       ..organizationId = organizationId
       ..sqlQuery = query;
     final response = await _dataClient.tabularDataBySQL(request);
-    // return response.data.map((e) => e.toMap()).toList();
     return response.rawData.map((e) => BsonCodec.deserialize(BsonBinary.from(e))).toList();
   }
 
@@ -101,7 +100,6 @@ class DataClient {
       ..organizationId = organizationId
       ..mqlBinary.addAll(query);
     final response = await _dataClient.tabularDataByMQL(request);
-    // return response.data.map((e) => e.toMap()).toList();
     return response.rawData.map((e) => BsonCodec.deserialize(BsonBinary.from(e))).toList();
   }
 

--- a/lib/src/app/data.dart
+++ b/lib/src/app/data.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:async/async.dart';
+import 'package:bson/bson.dart' hide Timestamp;
 import 'package:collection/collection.dart';
 import 'package:fixnum/fixnum.dart';
 
@@ -82,12 +83,14 @@ class DataClient {
   /// Obtain unified tabular data and metadata, queried with SQL.
   ///
   /// For more information, see [Data Client API](https://docs.viam.com/appendix/apis/data-client/).
+  // List<List<int>>
   Future<List<Map<String, dynamic>>> tabularDataBySql(String organizationId, String query) async {
     final request = TabularDataBySQLRequest()
       ..organizationId = organizationId
       ..sqlQuery = query;
     final response = await _dataClient.tabularDataBySQL(request);
-    return response.data.map((e) => e.toMap()).toList();
+    // return response.data.map((e) => e.toMap()).toList();
+    return response.rawData.map((e) => BsonCodec.deserialize(BsonBinary.from(e))).toList();
   }
 
   /// Obtain unified tabular data and metadata, queried with MQL.
@@ -98,7 +101,8 @@ class DataClient {
       ..organizationId = organizationId
       ..mqlBinary.addAll(query);
     final response = await _dataClient.tabularDataByMQL(request);
-    return response.data.map((e) => e.toMap()).toList();
+    // return response.data.map((e) => e.toMap()).toList();
+    return response.rawData.map((e) => BsonCodec.deserialize(BsonBinary.from(e))).toList();
   }
 
   /// Delete tabular data older than a provided number of days from an organization.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   collection: ^1.17.1
   async: ^2.11.0
   bonsoir: ^5.1.8
+  bson: ^5.0.5
 
 dev_dependencies:
   flutter_test:

--- a/test/unit_test/app/data_client_test.dart
+++ b/test/unit_test/app/data_client_test.dart
@@ -142,9 +142,10 @@ void main() {
       });
 
       test('tabularDataBySql', () async {
+        final startDate = DateTime.utc(2020, 12, 31);
         final List<Map<String, dynamic>> data = [
           {
-            'key1': 1,
+            'key1': startDate,
             'key2': '2',
             'key3': [1, 2, 3],
             'key4': {'key4sub1': 1}
@@ -155,13 +156,15 @@ void main() {
             (_) => MockResponseFuture.value(TabularDataBySQLResponse()..rawData.addAll(data.map((e) => BsonCodec.serialize(e).byteList))));
 
         final response = await dataClient.tabularDataBySql('some_org_id', 'some_query');
+        expect(response[0]['key1'], equals(data[0]['key1']));
         expect(response, equals(data));
       });
 
       test('tabularDataByMql', () async {
+        final startDate = DateTime.utc(2020, 12, 31);
         final List<Map<String, dynamic>> data = [
           {
-            'key1': 1,
+            'key1': startDate.toUtc(),
             'key2': '2',
             'key3': [1, 2, 3],
             'key4': {'key4sub1': 1}
@@ -172,6 +175,7 @@ void main() {
             (_) => MockResponseFuture.value(TabularDataByMQLResponse()..rawData.addAll(data.map((e) => BsonCodec.serialize(e).byteList))));
 
         final response = await dataClient.tabularDataByMql('some_org_id', [Uint8List.fromList('some_query'.codeUnits)]);
+        expect(response[0]['key1'], equals(data[0]['key1']));
         expect(response, equals(data));
       });
 

--- a/test/unit_test/app/data_client_test.dart
+++ b/test/unit_test/app/data_client_test.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:bson/bson.dart' hide Timestamp;
 import 'package:fixnum/fixnum.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:grpc/src/client/call.dart';
@@ -13,7 +14,6 @@ import 'package:viam_sdk/src/gen/app/data/v1/data.pb.dart';
 import 'package:viam_sdk/src/gen/app/data/v1/data.pbgrpc.dart';
 import 'package:viam_sdk/src/gen/google/protobuf/timestamp.pb.dart';
 import 'package:viam_sdk/src/media/image.dart';
-import 'package:viam_sdk/src/utils.dart';
 
 import '../mocks/mock_response_future.dart';
 import '../mocks/service_clients_mocks.mocks.dart';
@@ -151,8 +151,8 @@ void main() {
           },
         ];
 
-        when(serviceClient.tabularDataBySQL(any))
-            .thenAnswer((_) => MockResponseFuture.value(TabularDataBySQLResponse()..data.addAll(data.map((e) => e.toStruct()))));
+        when(serviceClient.tabularDataBySQL(any)).thenAnswer(
+            (_) => MockResponseFuture.value(TabularDataBySQLResponse()..rawData.addAll(data.map((e) => BsonCodec.serialize(e).byteList))));
 
         final response = await dataClient.tabularDataBySql('some_org_id', 'some_query');
         expect(response, equals(data));
@@ -168,8 +168,8 @@ void main() {
           },
         ];
 
-        when(serviceClient.tabularDataByMQL(any))
-            .thenAnswer((_) => MockResponseFuture.value(TabularDataByMQLResponse()..data.addAll(data.map((e) => e.toStruct()))));
+        when(serviceClient.tabularDataByMQL(any)).thenAnswer(
+            (_) => MockResponseFuture.value(TabularDataByMQLResponse()..rawData.addAll(data.map((e) => BsonCodec.serialize(e).byteList))));
 
         final response = await dataClient.tabularDataByMql('some_org_id', [Uint8List.fromList('some_query'.codeUnits)]);
         expect(response, equals(data));


### PR DESCRIPTION
For context: The return type of the TabularDataBySQL/MQL proto has changed to return both a list of structs, the existing return type, and also a list of bytearrays that represent BSON.

Added a required dependency to bson to use the BSON library for dart
BSON provides a` BsonCodec.deserialize()` and `BsonCodec.serialize()` function for converting lists of byte sequences into lists of dart objects.

Testing:
Updated the `data` testing input to include `DateTime` objects, as the Flutter SDK will receive date fields in this format. I added a check to ensure that `DateTime` inputs are returned as native Flutter `DateTime` objects

I ensured that date fields are returned as native dart DateTime objects instead of strings by running tabularDataByMQL against real tabular data on viam-dev and printed the decoded data and their types. As you can see below the date and time elements are of type "DateTime":
<img width="594" alt="Screenshot 2024-10-31 at 4 20 47 PM" src="https://github.com/user-attachments/assets/65771fee-5e06-40a8-87cd-e5ef4d82ed69">