### PR TITLE
Reset stream in camera_stream if camera changes

### DIFF
--- a/lib/widgets/camera_stream.dart
+++ b/lib/widgets/camera_stream.dart
@@ -34,10 +34,17 @@ class _ViamCameraStreamViewState extends State<ViamCameraStreamView> {
   }
 
   @override
+  void didUpdateWidget(ViamCameraStreamView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.camera != widget.camera) {
+      _cleanupStream();
+      _startStream();
+    }
+  }
+
+  @override
   void dispose() {
-    _renderer.dispose();
-    _streamSub.cancel();
-    widget.streamClient.closeStream();
+    _cleanupStream();
     super.dispose();
   }
 
@@ -68,6 +75,12 @@ class _ViamCameraStreamViewState extends State<ViamCameraStreamView> {
         _error = error;
       });
     });
+  }
+
+  void _cleanupStream() {
+    _renderer.dispose();
+    _streamSub.cancel();
+    widget.streamClient.closeStream();
   }
 
   @override


### PR DESCRIPTION
Was just using this widget in a way where the camera will be updated as a user cycles through a list of cameras. 

The camera was updating but the stream wouldn't restart because it only starts 1 time in `initState()`