### PR TITLE
[RSDK-9250] - Add stream options handlers

### DIFF
--- a/lib/src/media/stream/client.dart
+++ b/lib/src/media/stream/client.dart
@@ -85,6 +85,43 @@ class StreamManager {
     return client;
   }
 
+  Future<List<Resolution>> getStreamOptions(String name) async {
+    final sanitizedName = _getValidSDPTrackName(name);
+    try {
+      final response = await _client.getStreamOptions(GetStreamOptionsRequest()..name = sanitizedName);
+      _logger.d('Got options for stream named $name');
+      return response.resolutions;
+    } catch (e) {
+      _logger.e('Failed to get options for stream named $name');
+      return [];
+    }
+  }
+
+  Future<void> setStreamOptions(String name, int width, int height) async {
+    final sanitizedName = _getValidSDPTrackName(name);
+    final resolution = Resolution()
+      ..width = width
+      ..height = height;
+    try {
+      await _client.setStreamOptions(SetStreamOptionsRequest()
+        ..name = sanitizedName
+        ..resolution = resolution);
+      _logger.d('Set options for stream named $name');
+    } catch (e) {
+      _logger.e('Failed to set options for stream named $name');
+    }
+  }
+
+  Future<void> resetStreamOptions(String name) async {
+    final sanitizedName = _getValidSDPTrackName(name);
+    try {
+      await _client.setStreamOptions(SetStreamOptionsRequest()..name = sanitizedName);
+      _logger.d('Reset options for stream named $name');
+    } catch (e) {
+      _logger.e('Failed to reset options for stream named $name');
+    }
+  }
+
   /// Request that a stream get added to the WebRTC channel
   Future<void> _add(String name) async {
     final sanitizedName = _getValidSDPTrackName(name);

--- a/lib/src/robot/client.dart
+++ b/lib/src/robot/client.dart
@@ -7,6 +7,7 @@ import 'package:logger/logger.dart';
 import '../gen/common/v1/common.pb.dart';
 import '../gen/google/protobuf/struct.pb.dart';
 import '../gen/robot/v1/robot.pbgrpc.dart' as rpb;
+import '../gen/stream/v1/stream.pbgrpc.dart';
 import '../media/stream/client.dart';
 import '../resource/base.dart';
 import '../resource/manager.dart';
@@ -297,6 +298,21 @@ class RobotClient {
   /// Get a WebRTC stream client with the given name.
   StreamClient getStream(String name) {
     return _streamManager.getStreamClient(name);
+  }
+
+  /// Get the stream options for a stream with the given name.
+  Future<List<Resolution>> getStreamOptions(String name) async {
+    return _streamManager.getStreamOptions(name);
+  }
+
+  /// Set the options for a stream with the given name.
+  Future<void> setStreamOptions(String name, int width, int height) {
+    return _streamManager.setStreamOptions(name, width, height);
+  }
+
+  // Reset the options for a stream with the given name.
+  Future<void> resetStreamOptions(String name) {
+    return _streamManager.resetStreamOptions(name);
   }
 
   /// Get app-related information about the machine.

--- a/lib/src/robot/client.dart
+++ b/lib/src/robot/client.dart
@@ -310,7 +310,7 @@ class RobotClient {
     return _streamManager.setStreamOptions(name, width, height);
   }
 
-  // Reset the options for a stream with the given name.
+  /// Reset the options for a stream with the given name.
   Future<void> resetStreamOptions(String name) {
     return _streamManager.resetStreamOptions(name);
   }


### PR DESCRIPTION
## Description

Adds handlers to the stream and robot client to hit options endpoints.

## Tests

Tested using local flutter web app that fires the following code block.

```dart
    final machine = await RobotClient.atAddress(
      host,
      RobotClientOptions.withApiKey(apiKeyID, apiKey),
    );
    final res = await machine.getStreamOptions("wc-cam");
    print(res);
    await machine.setStreamOptions("wc-cam", res[1].width, res[1].height);
    await machine.resetStreamOptions("wc-cam");
    await machine.close();
```