### PR TITLE
Fix building example project for iOS

### DIFF
--- a/example/viam_example_app/ios/Flutter/Debug.xcconfig
+++ b/example/viam_example_app/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include "Generated.xcconfig"


### PR DESCRIPTION
When trying to build `viam_example_app` for iOS you will encounter this error:

```
/bin/sh: /packages/flutter_tools/bin/xcode_backend.sh: No such file or directory
Command PhaseScriptExecution failed with a nonzero exit code
```

That's because the [failing script](https://github.com/viamrobotics/viam-flutter-sdk/blob/5eda81a7a55546447d07a793b05983154050d4e1/example/viam_example_app/ios/Runner.xcodeproj/project.pbxproj#L350) references `FLUTTER_ROOT` which is undefined

The `Generated.xcconfig` file defines `FLUTTER_ROOT` as well as [several other properties](https://github.com/jonataslaw/easy/blob/master/example/ios/Flutter/Generated.xcconfig). Including this in the `Debug.xcconfig` resolves the error

Encountered this error while pairing w/ @benjirewis when he was trying to run the example