### PR TITLE
Add includeBinary to data funcs

### DIFF
--- a/lib/src/app/data.dart
+++ b/lib/src/app/data.dart
@@ -123,19 +123,22 @@ class DataClient {
   ///
   /// For more information, see [Data Client API](https://docs.viam.com/appendix/apis/data-client/).
   Future<BinaryDataByFilterResponse> binaryDataByFilter(
-      {Filter? filter, int? limit, Order? sortOrder, String? last, countOnly = false}) async {
+      {Filter? filter, int? limit, Order? sortOrder, String? last, bool countOnly = false, bool includeBinary = false}) async {
     final dataRequest = _makeDataRequest(filter, limit, last, sortOrder);
     final request = BinaryDataByFilterRequest()
       ..dataRequest = dataRequest
-      ..countOnly = false;
+      ..countOnly = countOnly
+      ..includeBinary = includeBinary;
     return await _dataClient.binaryDataByFilter(request);
   }
 
   /// Retrieve binary data by IDs
   ///
   /// For more information, see [Data Client API](https://docs.viam.com/appendix/apis/data-client/).
-  Future<List<BinaryData>> binaryDataByIds(List<BinaryID> binaryIds) async {
-    final request = BinaryDataByIDsRequest()..binaryIds.addAll(binaryIds);
+  Future<List<BinaryData>> binaryDataByIds(List<BinaryID> binaryIds, {bool includeBinary = false}) async {
+    final request = BinaryDataByIDsRequest()
+      ..binaryIds.addAll(binaryIds)
+      ..includeBinary = includeBinary;
     final response = await _dataClient.binaryDataByIDs(request);
     return response.data;
   }

--- a/lib/src/app/data.dart
+++ b/lib/src/app/data.dart
@@ -135,12 +135,12 @@ class DataClient {
   /// Retrieve binary data by IDs
   ///
   /// For more information, see [Data Client API](https://docs.viam.com/appendix/apis/data-client/).
-  Future<List<BinaryData>> binaryDataByIds(List<BinaryID> binaryIds, {bool includeBinary = false}) async {
+  Future<BinaryDataByIDsResponse> binaryDataByIds(List<BinaryID> binaryIds, {bool includeBinary = false}) async {
     final request = BinaryDataByIDsRequest()
       ..binaryIds.addAll(binaryIds)
       ..includeBinary = includeBinary;
     final response = await _dataClient.binaryDataByIDs(request);
-    return response.data;
+    return response;
   }
 
   /// Obtain unified tabular data and metadata, queried with SQL.

--- a/test/unit_test/app/data_client_test.dart
+++ b/test/unit_test/app/data_client_test.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:bson/bson.dart' hide Timestamp;
 import 'package:fixnum/fixnum.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -101,14 +99,20 @@ void main() {
         const limit = 10;
         const last = 'last';
         const sortOrder = Order.ORDER_ASCENDING;
+        bool includeBinary = false;
 
-        when(serviceClient.binaryDataByFilter(any)).thenAnswer((_) => MockResponseFuture.value(BinaryDataByFilterResponse()
-          ..count = Int64(limit)
-          ..last = last));
+        when(serviceClient.binaryDataByFilter(any)).thenAnswer((invocation) {
+          includeBinary = (invocation.positionalArguments[0] as BinaryDataByFilterRequest).includeBinary;
+          return MockResponseFuture.value(BinaryDataByFilterResponse()
+            ..count = Int64(limit)
+            ..last = last);
+        });
 
-        final response = await dataClient.binaryDataByFilter(filter: filter, limit: limit, sortOrder: sortOrder, last: last);
+        final response =
+            await dataClient.binaryDataByFilter(filter: filter, limit: limit, sortOrder: sortOrder, last: last, includeBinary: true);
         expect(response.count, equals(Int64(limit)));
         expect(response.last, equals(last));
+        expect(includeBinary, isTrue);
       });
 
       test('binaryDataByFilter_countOnly', () async {
@@ -135,11 +139,16 @@ void main() {
           BinaryData()..binary = [2, 3, 4, 5],
           BinaryData()..binary = [3, 4, 5, 6],
         ];
+        bool includeBinary = false;
 
-        when(serviceClient.binaryDataByIDs(any)).thenAnswer((_) => MockResponseFuture.value(BinaryDataByIDsResponse()..data.addAll(data)));
+        when(serviceClient.binaryDataByIDs(any)).thenAnswer((invocation) {
+          includeBinary = (invocation.positionalArguments[0] as BinaryDataByIDsRequest).includeBinary;
+          return MockResponseFuture.value(BinaryDataByIDsResponse()..data.addAll(data));
+        });
 
-        final response = await dataClient.binaryDataByIds(ids);
+        final response = await dataClient.binaryDataByIds(ids, includeBinary: true);
         expect(response, equals(data));
+        expect(includeBinary, isTrue);
       });
 
       test('tabularDataBySql', () async {

--- a/test/unit_test/app/data_client_test.dart
+++ b/test/unit_test/app/data_client_test.dart
@@ -147,7 +147,7 @@ void main() {
         });
 
         final response = await dataClient.binaryDataByIds(ids, includeBinary: true);
-        expect(response, equals(data));
+        expect(response.data, equals(data));
         expect(includeBinary, isTrue);
       });
 


### PR DESCRIPTION
**BREAKING CHANGE**
We were missing the param to actually download the data. In the process of changing that, I had to change the return type of `binaryDataByIDs` since the user can request just the count now. 

As a flyby, I fixed `binaryDataByFilter` to actually use `countOnly`
