### PR TITLE
RSDK-9622 FIX: fix discoverResources input parameters 

### DIFF
--- a/lib/src/services/discovery.dart
+++ b/lib/src/services/discovery.dart
@@ -1,10 +1,10 @@
 import 'package:grpc/grpc_connection_interface.dart';
 
 import '../../protos/common/common.dart';
-import '../gen/common/v1/common.pb.dart';
 import '../../protos/service/discovery.dart';
-import '../gen/service/discovery/v1/discovery.pbgrpc.dart';
 import '../gen/app/v1/robot.pb.dart';
+import '../gen/common/v1/common.pb.dart';
+import '../gen/service/discovery/v1/discovery.pbgrpc.dart';
 import '../resource/base.dart';
 import '../robot/client.dart';
 import '../utils.dart';
@@ -30,7 +30,7 @@ class DiscoveryClient extends Resource implements ResourceRPCClient {
   /// // Example:
   /// var resources = await myDiscoveryService.discoverResources('myWebcam');
   /// ```
-  Future<List<ComponentConfig>> discoverResources(String discoveryName, {Map<String, dynamic>? extra}) async {
+  Future<List<ComponentConfig>> discoverResources({Map<String, dynamic>? extra}) async {
     final request = DiscoverResourcesRequest(name: name, extra: extra?.toStruct());
     final response = await client.discoverResources(request);
     return response.discoveries;

--- a/test/unit_test/services/discovery_test.dart
+++ b/test/unit_test/services/discovery_test.dart
@@ -1,11 +1,9 @@
-import 'package:fixnum/fixnum.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:viam_sdk/protos/service/discovery.dart';
-import 'package:viam_sdk/src/gen/common/v1/common.pb.dart';
+import 'package:viam_sdk/src/gen/app/v1/robot.pb.dart';
 import 'package:viam_sdk/src/gen/service/discovery/v1/discovery.pbgrpc.dart';
 import 'package:viam_sdk/viam_sdk.dart';
-import 'package:viam_sdk/src/gen/app/v1/robot.pb.dart';
 
 import '../mocks/mock_response_future.dart';
 import '../mocks/service_clients_mocks.mocks.dart';
@@ -33,7 +31,7 @@ void main() {
       final expected = [ComponentConfig()];
       when(serviceClient.discoverResources(any))
           .thenAnswer((_) => MockResponseFuture.value(DiscoverResourcesResponse(discoveries: expected)));
-      final response = await client.discoverResources('discoveryName');
+      final response = await client.discoverResources();
       expect(response, equals(expected));
     });
   });


### PR DESCRIPTION
I had previously thought a `discoveryName` needed to be passed in to `discoverResources`. I realized while using this new method in flutter that I forgot to remove the input parameter after changing the function to use `this.name`. 