### PR TITLE
[RSDK-9633] delete discover components

### DIFF
--- a/lib/src/robot/client.dart
+++ b/lib/src/robot/client.dart
@@ -336,26 +336,6 @@ class RobotClient {
     return await _client.getCloudMetadata(rpb.GetCloudMetadataRequest());
   }
 
-  /// Deprecated: use the Discovery Service APIs instead.
-  ///
-  /// Discover components that the robot can connect to, given specific query metadata.
-  ///
-  /// ```
-  /// var queries = [DiscoveryQuery(subtype: 'camera', model: 'webcam', extra: {'username': 'admin', 'password': 'admin'})];
-  /// var discoveredComponents = await machine.discoverComponents(queries);
-  /// ```
-  Future<List<Discovery>> discoverComponents([List<DiscoveryQuery> queries = const []]) async {
-    final request = rpb.DiscoverComponentsRequest()
-      ..queries.addAll(queries.map((sdkQuery) => rpb.DiscoveryQuery()
-        ..subtype = sdkQuery.subtype
-        ..model = sdkQuery.model
-        ..extra = sdkQuery.extraStruct));
-
-    _logger.w("RobotClient.discoverComponents is deprecated. It will be removed on March 10 2025. Use the DiscoveryService APIs instead.");
-    final response = await _client.discoverComponents(request);
-    return response.discovery.map((d) => Discovery.fromProto(d)).toList();
-  }
-
   /// GetModelsFromModules returns the list of models supported in modules on the machine.
   ///
   /// ```

--- a/lib/src/robot/client.dart
+++ b/lib/src/robot/client.dart
@@ -57,20 +57,6 @@ class RobotClientOptions {
 }
 
 /// {@category Viam SDK}
-/// Represents a discovery query in the SDK to query for discoverable components.
-///
-/// deprecated, remove on march 10th
-class DiscoveryQuery {
-  final String subtype;
-  final String model;
-  final Map<String, dynamic> extra;
-
-  DiscoveryQuery({required this.subtype, required this.model, Map<String, dynamic>? extra}) : extra = extra ?? {};
-
-  Struct get extraStruct => extra.toStruct();
-}
-
-/// {@category Viam SDK}
 /// Represents the result of a discovery query.
 class Discovery {
   final String subtype;

--- a/test/unit_test/mocks/service_clients_mocks.mocks.dart
+++ b/test/unit_test/mocks/service_clients_mocks.mocks.dart
@@ -356,37 +356,6 @@ class MockRobotServiceClient extends _i1.Mock
           as _i4.ResponseFuture<_i9.GetModelsFromModulesResponse>);
 
   @override
-  _i4.ResponseFuture<_i9.DiscoverComponentsResponse> discoverComponents(
-    _i9.DiscoverComponentsRequest? request, {
-    _i3.CallOptions? options,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #discoverComponents,
-              [request],
-              {#options: options},
-            ),
-            returnValue: _FakeResponseFuture_2<_i9.DiscoverComponentsResponse>(
-              this,
-              Invocation.method(
-                #discoverComponents,
-                [request],
-                {#options: options},
-              ),
-            ),
-            returnValueForMissingStub:
-                _FakeResponseFuture_2<_i9.DiscoverComponentsResponse>(
-                  this,
-                  Invocation.method(
-                    #discoverComponents,
-                    [request],
-                    {#options: options},
-                  ),
-                ),
-          )
-          as _i4.ResponseFuture<_i9.DiscoverComponentsResponse>);
-
-  @override
   _i4.ResponseFuture<_i9.FrameSystemConfigResponse> frameSystemConfig(
     _i9.FrameSystemConfigRequest? request, {
     _i3.CallOptions? options,


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-9633

assuming I'm not supposed to delete the gen files, but otherwise I am deleting DiscoverComponents from everywhere. 

api pr: https://github.com/viamrobotics/api/pull/638 