### PR TITLE
RSDK-9900 - always find unused port for testing

### DIFF
--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 Future<int> getUnusedPort() {
-    return ServerSocket.bind(InternetAddress.anyIPv4, 0).then((socket) {
+  return ServerSocket.bind(InternetAddress.loopbackIPv4, 0).then((socket) {
     final port = socket.port;
     socket.close();
     return port;

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -1,6 +1,14 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
-int generateTestingPortFromName(String name) => 50000 + (name.hashCode % 10000);
+Future<int> getUnusedPort() {
+    return ServerSocket.bind(InternetAddress.anyIPv4, 0).then((socket) {
+    final port = socket.port;
+    socket.close();
+    return port;
+  });
+}
 
 class TestableWidget extends StatelessWidget {
   const TestableWidget({

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -3,10 +3,14 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
-Future<int> getUnusedPort(FutureOr<int> Function(int port) tryPort) async {
+Future<int> getUnusedPort() async {
   int? value;
   await Future.doWhile(() async {
-    value = await tryPort(await getUnsafeUnusedPort());
+    value = await ServerSocket.bind(InternetAddress.loopbackIPv4, await getUnsafeUnusedPort()).then((socket) {
+      final port = socket.port;
+      socket.close();
+      return port;
+    });
     return value == null;
   });
 

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -1,13 +1,26 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
 
-Future<int> getUnusedPort() {
-  return ServerSocket.bind(InternetAddress.loopbackIPv4, 0).then((socket) {
-    final port = socket.port;
-    socket.close();
-    return port;
+Future<int> getUnusedPort(FutureOr<int> Function(int port) tryPort) async {
+  int? value;
+  await Future.doWhile(() async {
+    value = await tryPort(await getUnsafeUnusedPort());
+    return value == null;
   });
+
+  // We need to set `value` to _something_ to appease typechecker, but in truth we'll never
+  // get here until `value` is non-null
+  return value ?? 54321;
+}
+
+Future<int> getUnsafeUnusedPort() async {
+  late int port;
+  final socket = await RawServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  port = socket.port;
+  await socket.close();
+  return port;
 }
 
 class TestableWidget extends StatelessWidget {

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -4,20 +4,17 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:grpc/grpc.dart';
 
-Future<ClientChannel> getChannelAndServeServerAtUnusedPort(Server server) async {
-  ClientChannel? chan;
+// Given a server, find a port to safely serve on and do so
+Future<void> serveServerAtUnusedPort(Server server) async {
   await Future.doWhile(() async {
     final port = await getUnsafeUnusedPort();
     try {
-      chan = ClientChannel('localhost', port: port, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
       await server.serve(port: port);
       return false;
     } catch (err) {
       return true;
     }
   });
-
-  return chan!;
 }
 
 Future<int> getUnsafeUnusedPort() async {

--- a/test/unit_test/components/arm_test.dart
+++ b/test/unit_test/components/arm_test.dart
@@ -141,14 +141,12 @@ void main() {
     late Server server;
 
     setUp(() async {
-      final port = await getUnusedPort();
       arm = FakeArm(name);
       final ResourceManager manager = ResourceManager();
       manager.register(Arm.getResourceName(name), arm);
       service = ArmService(manager);
-      channel = ClientChannel('localhost', port: port, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
       server = Server.create(services: [service]);
-      await server.serve(port: port);
+      channel = await getChannelAndServeServerAtUnusedPort(server);
     });
 
     tearDown(() async {

--- a/test/unit_test/components/arm_test.dart
+++ b/test/unit_test/components/arm_test.dart
@@ -146,7 +146,8 @@ void main() {
       manager.register(Arm.getResourceName(name), arm);
       service = ArmService(manager);
       server = Server.create(services: [service]);
-      channel = await getChannelAndServeServerAtUnusedPort(server);
+      await serveServerAtUnusedPort(server);
+      channel = ClientChannel('localhost', port: server.port!, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
     });
 
     tearDown(() async {

--- a/test/unit_test/components/arm_test.dart
+++ b/test/unit_test/components/arm_test.dart
@@ -141,7 +141,7 @@ void main() {
     late Server server;
 
     setUp(() async {
-      final port = generateTestingPortFromName(name);
+      final port = await getUnusedPort();
       arm = FakeArm(name);
       final ResourceManager manager = ResourceManager();
       manager.register(Arm.getResourceName(name), arm);

--- a/test/unit_test/components/board_test.dart
+++ b/test/unit_test/components/board_test.dart
@@ -207,7 +207,7 @@ void main() {
     late Server server;
 
     setUp(() async {
-      final port = generateTestingPortFromName(name);
+      final port = await getUnusedPort();
       board = FakeBoard(name);
       final ResourceManager manager = ResourceManager();
       manager.register(Board.getResourceName(name), board);

--- a/test/unit_test/components/board_test.dart
+++ b/test/unit_test/components/board_test.dart
@@ -207,14 +207,12 @@ void main() {
     late Server server;
 
     setUp(() async {
-      final port = await getUnusedPort();
       board = FakeBoard(name);
       final ResourceManager manager = ResourceManager();
       manager.register(Board.getResourceName(name), board);
       service = BoardService(manager);
-      channel = ClientChannel('localhost', port: port, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
       server = Server.create(services: [service]);
-      await server.serve(port: port);
+      channel = await getChannelAndServeServerAtUnusedPort(server);
     });
 
     tearDown(() async {

--- a/test/unit_test/components/board_test.dart
+++ b/test/unit_test/components/board_test.dart
@@ -212,7 +212,8 @@ void main() {
       manager.register(Board.getResourceName(name), board);
       service = BoardService(manager);
       server = Server.create(services: [service]);
-      channel = await getChannelAndServeServerAtUnusedPort(server);
+      await serveServerAtUnusedPort(server);
+      channel = ClientChannel('localhost', port: server.port!, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
     });
 
     tearDown(() async {

--- a/test/unit_test/components/camera_test.dart
+++ b/test/unit_test/components/camera_test.dart
@@ -104,7 +104,8 @@ void main() {
       manager.register(Camera.getResourceName(name), camera);
       service = CameraService(manager);
       server = Server.create(services: [service]);
-      channel = await getChannelAndServeServerAtUnusedPort(server);
+      await serveServerAtUnusedPort(server);
+      channel = ClientChannel('localhost', port: server.port!, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
     });
 
     tearDown(() async {

--- a/test/unit_test/components/camera_test.dart
+++ b/test/unit_test/components/camera_test.dart
@@ -100,13 +100,11 @@ void main() {
 
     setUp(() async {
       camera = FakeCamera(name);
-      final port = await getUnusedPort();
       final manager = ResourceManager();
       manager.register(Camera.getResourceName(name), camera);
       service = CameraService(manager);
-      channel = ClientChannel('localhost', port: port, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
       server = Server.create(services: [service]);
-      await server.serve(port: port);
+      channel = await getChannelAndServeServerAtUnusedPort(server);
     });
 
     tearDown(() async {

--- a/test/unit_test/components/camera_test.dart
+++ b/test/unit_test/components/camera_test.dart
@@ -100,7 +100,7 @@ void main() {
 
     setUp(() async {
       camera = FakeCamera(name);
-      final port = generateTestingPortFromName(name);
+      final port = await getUnusedPort();
       final manager = ResourceManager();
       manager.register(Camera.getResourceName(name), camera);
       service = CameraService(manager);

--- a/test/unit_test/components/gantry_test.dart
+++ b/test/unit_test/components/gantry_test.dart
@@ -137,7 +137,7 @@ void main() {
     late Server server;
 
     setUp(() async {
-      final port = generateTestingPortFromName(name);
+      final port = await getUnusedPort();
       gantry = FakeGantry(name, lengths);
       final ResourceManager manager = ResourceManager();
       manager.register(Gantry.getResourceName(name), gantry);

--- a/test/unit_test/components/gantry_test.dart
+++ b/test/unit_test/components/gantry_test.dart
@@ -137,14 +137,12 @@ void main() {
     late Server server;
 
     setUp(() async {
-      final port = await getUnusedPort();
       gantry = FakeGantry(name, lengths);
       final ResourceManager manager = ResourceManager();
       manager.register(Gantry.getResourceName(name), gantry);
       service = GantryService(manager);
-      channel = ClientChannel('localhost', port: port, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
       server = Server.create(services: [service]);
-      await server.serve(port: port);
+      channel = await getChannelAndServeServerAtUnusedPort(server);
     });
 
     tearDown(() async {

--- a/test/unit_test/components/gantry_test.dart
+++ b/test/unit_test/components/gantry_test.dart
@@ -142,7 +142,8 @@ void main() {
       manager.register(Gantry.getResourceName(name), gantry);
       service = GantryService(manager);
       server = Server.create(services: [service]);
-      channel = await getChannelAndServeServerAtUnusedPort(server);
+      await serveServerAtUnusedPort(server);
+      channel = ClientChannel('localhost', port: server.port!, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
     });
 
     tearDown(() async {

--- a/test/unit_test/components/gripper_test.dart
+++ b/test/unit_test/components/gripper_test.dart
@@ -117,7 +117,8 @@ void main() {
       manager.register(Gripper.getResourceName(name), gripper);
       service = GripperService(manager);
       server = Server.create(services: [service]);
-      channel = await getChannelAndServeServerAtUnusedPort(server);
+      await serveServerAtUnusedPort(server);
+      channel = ClientChannel('localhost', port: server.port!, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
     });
 
     tearDown(() async {

--- a/test/unit_test/components/gripper_test.dart
+++ b/test/unit_test/components/gripper_test.dart
@@ -112,7 +112,7 @@ void main() {
     late Server server;
 
     setUp(() async {
-      final port = generateTestingPortFromName(name);
+      final port = await getUnusedPort();
       gripper = FakeGripper(name);
       final ResourceManager manager = ResourceManager();
       manager.register(Gripper.getResourceName(name), gripper);

--- a/test/unit_test/components/gripper_test.dart
+++ b/test/unit_test/components/gripper_test.dart
@@ -112,14 +112,12 @@ void main() {
     late Server server;
 
     setUp(() async {
-      final port = await getUnusedPort();
       gripper = FakeGripper(name);
       final ResourceManager manager = ResourceManager();
       manager.register(Gripper.getResourceName(name), gripper);
       service = GripperService(manager);
-      channel = ClientChannel('localhost', port: port, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
       server = Server.create(services: [service]);
-      await server.serve(port: port);
+      channel = await getChannelAndServeServerAtUnusedPort(server);
     });
 
     tearDown(() async {

--- a/test/unit_test/components/motor_test.dart
+++ b/test/unit_test/components/motor_test.dart
@@ -202,7 +202,7 @@ void main() {
     late Server server;
 
     setUp(() async {
-      final port = generateTestingPortFromName(name);
+      final port = await getUnusedPort();
       motor = FakeMotor(name);
       final ResourceManager manager = ResourceManager();
       manager.register(Motor.getResourceName(name), motor);

--- a/test/unit_test/components/motor_test.dart
+++ b/test/unit_test/components/motor_test.dart
@@ -202,14 +202,12 @@ void main() {
     late Server server;
 
     setUp(() async {
-      final port = await getUnusedPort();
       motor = FakeMotor(name);
       final ResourceManager manager = ResourceManager();
       manager.register(Motor.getResourceName(name), motor);
       service = MotorService(manager);
-      channel = ClientChannel('localhost', port: port, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
       server = Server.create(services: [service]);
-      await server.serve(port: port);
+      channel = await getChannelAndServeServerAtUnusedPort(server);
     });
 
     tearDown(() async {

--- a/test/unit_test/components/motor_test.dart
+++ b/test/unit_test/components/motor_test.dart
@@ -207,7 +207,8 @@ void main() {
       manager.register(Motor.getResourceName(name), motor);
       service = MotorService(manager);
       server = Server.create(services: [service]);
-      channel = await getChannelAndServeServerAtUnusedPort(server);
+      await serveServerAtUnusedPort(server);
+      channel = ClientChannel('localhost', port: server.port!, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
     });
 
     tearDown(() async {

--- a/test/unit_test/utils/utils_test.dart
+++ b/test/unit_test/utils/utils_test.dart
@@ -10,18 +10,6 @@ import 'package:viam_sdk/src/utils.dart';
 import '../../test_utils.dart';
 
 void main() {
-  group('test utils', () {
-    test('generateTestingPortFromName', () {
-      final a = generateTestingPortFromName('a');
-      final b = generateTestingPortFromName('b');
-      expect((a != b), true);
-
-      final c1 = generateTestingPortFromName('c');
-      final c2 = generateTestingPortFromName('c');
-      expect((c1 == c2), true);
-    });
-  });
-
   group('utils', () {
     group('NullableStringUtils', () {
       const String? nullString = null;


### PR DESCRIPTION
Changes the logic for finding a port for tests to ensure that the found port is unused.

It's hard to be absolutely confident this is right, since the failure is flaky and hard to reproduce reliably. But, the logic of the change seems sound to me, and is cribbed from logic [used by dart internally](https://chromium.googlesource.com/external/github.com/dart-lang/test/+/master/pkgs/test_core/lib/src/util/io.dart#147) for testing. I figure if it's good enough for the dart team, it's probably good enough for us!