### PR TITLE
[RSDK-9110] Add trace debug logging

### DIFF
--- a/lib/src/components/arm/client.dart
+++ b/lib/src/components/arm/client.dart
@@ -11,7 +11,7 @@ import 'arm.dart';
 /// gRPC client for an [Arm] component.
 ///
 /// Used to communicate with an existing [Arm] implementation over gRPC.
-class ArmClient extends Arm implements ResourceRPCClient {
+class ArmClient extends Arm with RPCDebugLoggerMixin implements ResourceRPCClient {
   @override
   final String name;
 
@@ -28,14 +28,14 @@ class ArmClient extends Arm implements ResourceRPCClient {
     final request = GetEndPositionRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getEndPosition(request);
+    final response = await client.getEndPosition(request, options: callOptions);
     return response.pose;
   }
 
   @override
   Future<bool> isMoving() async {
     final request = IsMovingRequest()..name = name;
-    final response = await client.isMoving(request);
+    final response = await client.isMoving(request, options: callOptions);
     return response.isMoving;
   }
 
@@ -45,7 +45,7 @@ class ArmClient extends Arm implements ResourceRPCClient {
       ..name = name
       ..positions = (JointPositions()..values.addAll(positions))
       ..extra = extra?.toStruct() ?? Struct();
-    await client.moveToJointPositions(request);
+    await client.moveToJointPositions(request, options: callOptions);
   }
 
   @override
@@ -54,7 +54,7 @@ class ArmClient extends Arm implements ResourceRPCClient {
       ..name = name
       ..to = pose
       ..extra = extra?.toStruct() ?? Struct();
-    await client.moveToPosition(request);
+    await client.moveToPosition(request, options: callOptions);
   }
 
   @override
@@ -62,7 +62,7 @@ class ArmClient extends Arm implements ResourceRPCClient {
     final request = GetJointPositionsRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getJointPositions(request);
+    final response = await client.getJointPositions(request, options: callOptions);
     return response.positions.values;
   }
 
@@ -71,7 +71,7 @@ class ArmClient extends Arm implements ResourceRPCClient {
     final request = StopRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    await client.stop(request);
+    await client.stop(request, options: callOptions);
   }
 
   @override
@@ -79,7 +79,7 @@ class ArmClient extends Arm implements ResourceRPCClient {
     final request = DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 }

--- a/lib/src/components/base/client.dart
+++ b/lib/src/components/base/client.dart
@@ -10,7 +10,7 @@ import 'base.dart';
 
 /// {@category Components}
 /// gRPC client for the [Base] component.
-class BaseClient extends Base implements ResourceRPCClient {
+class BaseClient extends Base with RPCDebugLoggerMixin implements ResourceRPCClient {
   @override
   final String name;
 
@@ -25,7 +25,7 @@ class BaseClient extends Base implements ResourceRPCClient {
   @override
   Future<bool> isMoving() async {
     final request = IsMovingRequest()..name = name;
-    final response = await client.isMoving(request);
+    final response = await client.isMoving(request, options: callOptions);
     return response.isMoving;
   }
 
@@ -36,7 +36,7 @@ class BaseClient extends Base implements ResourceRPCClient {
       ..distanceMm = Int64(distance)
       ..mmPerSec = velocity
       ..extra = extra?.toStruct() ?? Struct();
-    await client.moveStraight(request);
+    await client.moveStraight(request, options: callOptions);
   }
 
   @override
@@ -46,7 +46,7 @@ class BaseClient extends Base implements ResourceRPCClient {
       ..linear = linear
       ..angular = angular
       ..extra = extra?.toStruct() ?? Struct();
-    await client.setPower(request);
+    await client.setPower(request, options: callOptions);
   }
 
   @override
@@ -56,7 +56,7 @@ class BaseClient extends Base implements ResourceRPCClient {
       ..linear = linear
       ..angular = angular
       ..extra = extra?.toStruct() ?? Struct();
-    await client.setVelocity(request);
+    await client.setVelocity(request, options: callOptions);
   }
 
   @override
@@ -66,7 +66,7 @@ class BaseClient extends Base implements ResourceRPCClient {
       ..angleDeg = angle
       ..degsPerSec = velocity
       ..extra = extra?.toStruct() ?? Struct();
-    await client.spin(request);
+    await client.spin(request, options: callOptions);
   }
 
   @override
@@ -74,7 +74,7 @@ class BaseClient extends Base implements ResourceRPCClient {
     final request = StopRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    await client.stop(request);
+    await client.stop(request, options: callOptions);
   }
 
   @override
@@ -82,7 +82,7 @@ class BaseClient extends Base implements ResourceRPCClient {
     final request = GetPropertiesRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    return await client.getProperties(request);
+    return await client.getProperties(request, options: callOptions);
   }
 
   @override
@@ -90,7 +90,7 @@ class BaseClient extends Base implements ResourceRPCClient {
     final request = DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 }

--- a/lib/src/components/board/client.dart
+++ b/lib/src/components/board/client.dart
@@ -14,7 +14,7 @@ import 'board.dart';
 
 /// {@category Components}
 /// gRPC client for the [Board] component.
-class BoardClient extends Board implements ResourceRPCClient {
+class BoardClient extends Board with RPCDebugLoggerMixin implements ResourceRPCClient {
   @override
   final String name;
 
@@ -31,7 +31,7 @@ class BoardClient extends Board implements ResourceRPCClient {
     final request = common.DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 
@@ -42,7 +42,7 @@ class BoardClient extends Board implements ResourceRPCClient {
       ..pin = pin
       ..high = high
       ..extra = extra?.toStruct() ?? Struct();
-    await client.setGPIO(request);
+    await client.setGPIO(request, options: callOptions);
   }
 
   @override
@@ -51,7 +51,7 @@ class BoardClient extends Board implements ResourceRPCClient {
       ..name = name
       ..pin = pin
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getGPIO(request);
+    final response = await client.getGPIO(request, options: callOptions);
     return response.high;
   }
 
@@ -61,7 +61,7 @@ class BoardClient extends Board implements ResourceRPCClient {
       ..name = name
       ..pin = pin
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.pWM(request);
+    final response = await client.pWM(request, options: callOptions);
     return response.dutyCyclePct;
   }
 
@@ -72,7 +72,7 @@ class BoardClient extends Board implements ResourceRPCClient {
       ..pin = pin
       ..dutyCyclePct = dutyCyclePct
       ..extra = extra?.toStruct() ?? Struct();
-    await client.setPWM(request);
+    await client.setPWM(request, options: callOptions);
   }
 
   @override
@@ -81,7 +81,7 @@ class BoardClient extends Board implements ResourceRPCClient {
       ..name = name
       ..pin = pin
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.pWMFrequency(request);
+    final response = await client.pWMFrequency(request, options: callOptions);
     return response.frequencyHz.toInt();
   }
 
@@ -92,7 +92,7 @@ class BoardClient extends Board implements ResourceRPCClient {
       ..pin = pin
       ..frequencyHz = Int64(frequencyHz)
       ..extra = extra?.toStruct() ?? Struct();
-    await client.setPWMFrequency(request);
+    await client.setPWMFrequency(request, options: callOptions);
   }
 
   @override
@@ -101,7 +101,7 @@ class BoardClient extends Board implements ResourceRPCClient {
       ..boardName = name
       ..analogReaderName = analogReaderName
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.readAnalogReader(request);
+    final response = await client.readAnalogReader(request, options: callOptions);
     return response;
   }
 
@@ -111,7 +111,7 @@ class BoardClient extends Board implements ResourceRPCClient {
       ..boardName = name
       ..digitalInterruptName = digitalInterruptName
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getDigitalInterruptValue(request);
+    final response = await client.getDigitalInterruptValue(request, options: callOptions);
     return response.value.toInt();
   }
 
@@ -123,10 +123,12 @@ class BoardClient extends Board implements ResourceRPCClient {
 
   @override
   Stream<Tick> streamTicks(List<String> interrupts, {Map<String, dynamic>? extra}) {
-    final response = client.streamTicks(StreamTicksRequest()
-      ..name = name
-      ..pinNames.addAll(interrupts)
-      ..extra = extra?.toStruct() ?? Struct());
+    final response = client.streamTicks(
+        StreamTicksRequest()
+          ..name = name
+          ..pinNames.addAll(interrupts)
+          ..extra = extra?.toStruct() ?? Struct(),
+        options: callOptions);
 
     final stream = response.map((resp) => Tick(pinName: resp.pinName, high: resp.high, time: resp.time));
     return stream.asBroadcastStream(onCancel: (_) => response.cancel());
@@ -142,7 +144,7 @@ class BoardClient extends Board implements ResourceRPCClient {
       ..powerMode = powerMode
       ..duration = duration
       ..extra = extra?.toStruct() ?? Struct();
-    await client.setPowerMode(request);
+    await client.setPowerMode(request, options: callOptions);
   }
 
   @override
@@ -152,6 +154,6 @@ class BoardClient extends Board implements ResourceRPCClient {
       ..pin = pin
       ..value = value
       ..extra = extra?.toStruct() ?? Struct();
-    await client.writeAnalog(request);
+    await client.writeAnalog(request, options: callOptions);
   }
 }

--- a/lib/src/components/button/client.dart
+++ b/lib/src/components/button/client.dart
@@ -9,7 +9,7 @@ import 'button.dart';
 
 /// {@category Components}
 /// gRPC client for the [Button] component.
-class ButtonClient extends Button implements ResourceRPCClient {
+class ButtonClient extends Button with RPCDebugLoggerMixin implements ResourceRPCClient {
   @override
   final String name;
 
@@ -26,7 +26,7 @@ class ButtonClient extends Button implements ResourceRPCClient {
     final request = PushRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    await client.push(request);
+    await client.push(request, options: callOptions);
   }
 
   @override
@@ -34,7 +34,7 @@ class ButtonClient extends Button implements ResourceRPCClient {
     final request = DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 }

--- a/lib/src/components/camera/client.dart
+++ b/lib/src/components/camera/client.dart
@@ -10,7 +10,7 @@ import 'camera.dart';
 
 /// {@category Components}
 /// gRPC client for the [Camera] component
-class CameraClient extends Camera implements ResourceRPCClient {
+class CameraClient extends Camera with RPCDebugLoggerMixin implements ResourceRPCClient {
   @override
   final String name;
 
@@ -28,7 +28,7 @@ class CameraClient extends Camera implements ResourceRPCClient {
       ..name = name
       ..mimeType = mimeType?.name ?? ''
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getImage(request);
+    final response = await client.getImage(request, options: callOptions);
     final actualMimeType = MimeType.fromString(response.mimeType);
     return ViamImage(response.image, actualMimeType);
   }
@@ -39,7 +39,7 @@ class CameraClient extends Camera implements ResourceRPCClient {
       ..name = name
       ..mimeType = MimeType.pcd.name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getPointCloud(request);
+    final response = await client.getPointCloud(request, options: callOptions);
     final actualMimeType = MimeType.fromString(response.mimeType);
     return ViamImage(response.pointCloud, actualMimeType);
   }
@@ -47,7 +47,7 @@ class CameraClient extends Camera implements ResourceRPCClient {
   @override
   Future<CameraProperties> properties() async {
     final request = GetPropertiesRequest()..name = name;
-    return await client.getProperties(request);
+    return await client.getProperties(request, options: callOptions);
   }
 
   @override
@@ -55,7 +55,7 @@ class CameraClient extends Camera implements ResourceRPCClient {
     final request = DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 }

--- a/lib/src/components/gantry/client.dart
+++ b/lib/src/components/gantry/client.dart
@@ -9,7 +9,7 @@ import 'gantry.dart';
 
 /// {@category Components}
 /// gRPC client for the [Gantry] component.
-class GantryClient extends Gantry implements ResourceRPCClient {
+class GantryClient extends Gantry with RPCDebugLoggerMixin implements ResourceRPCClient {
   @override
   final String name;
 
@@ -33,7 +33,7 @@ class GantryClient extends Gantry implements ResourceRPCClient {
     final request = GetLengthsRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getLengths(request);
+    final response = await client.getLengths(request, options: callOptions);
     return response.lengthsMm;
   }
 
@@ -42,7 +42,7 @@ class GantryClient extends Gantry implements ResourceRPCClient {
     final request = HomeRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.home(request);
+    final response = await client.home(request, options: callOptions);
     return response.homed;
   }
 
@@ -53,7 +53,7 @@ class GantryClient extends Gantry implements ResourceRPCClient {
       ..positionsMm.addAll(positions)
       ..speedsMmPerSec.addAll(speeds)
       ..extra = extra?.toStruct() ?? Struct();
-    await client.moveToPosition(request);
+    await client.moveToPosition(request, options: callOptions);
   }
 
   @override
@@ -61,7 +61,7 @@ class GantryClient extends Gantry implements ResourceRPCClient {
     final request = GetPositionRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getPosition(request);
+    final response = await client.getPosition(request, options: callOptions);
     return response.positionsMm;
   }
 
@@ -70,7 +70,7 @@ class GantryClient extends Gantry implements ResourceRPCClient {
     final request = StopRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    await client.stop(request);
+    await client.stop(request, options: callOptions);
   }
 
   @override
@@ -78,7 +78,7 @@ class GantryClient extends Gantry implements ResourceRPCClient {
     final request = DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 }

--- a/lib/src/components/generic/client.dart
+++ b/lib/src/components/generic/client.dart
@@ -8,7 +8,7 @@ import 'generic.dart';
 
 /// {@category Components}
 /// gRPC client for the [Generic] component.
-class GenericClient extends Generic implements ResourceRPCClient {
+class GenericClient extends Generic with RPCDebugLoggerMixin implements ResourceRPCClient {
   @override
   final String name;
 
@@ -25,7 +25,7 @@ class GenericClient extends Generic implements ResourceRPCClient {
     final request = DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 }

--- a/lib/src/components/gripper/client.dart
+++ b/lib/src/components/gripper/client.dart
@@ -9,7 +9,7 @@ import 'gripper.dart';
 
 /// {@category Components}
 /// gRPC client for the [Gripper] component.
-class GripperClient extends Gripper implements ResourceRPCClient {
+class GripperClient extends Gripper with RPCDebugLoggerMixin implements ResourceRPCClient {
   @override
   final String name;
 
@@ -26,13 +26,13 @@ class GripperClient extends Gripper implements ResourceRPCClient {
     final request = GrabRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    await client.grab(request);
+    await client.grab(request, options: callOptions);
   }
 
   @override
   Future<bool> isMoving() async {
     final request = IsMovingRequest()..name = name;
-    final response = await client.isMoving(request);
+    final response = await client.isMoving(request, options: callOptions);
     return response.isMoving;
   }
 
@@ -41,7 +41,7 @@ class GripperClient extends Gripper implements ResourceRPCClient {
     final request = OpenRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    await client.open(request);
+    await client.open(request, options: callOptions);
   }
 
   @override
@@ -49,7 +49,7 @@ class GripperClient extends Gripper implements ResourceRPCClient {
     final request = StopRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    await client.stop(request);
+    await client.stop(request, options: callOptions);
   }
 
   @override
@@ -57,7 +57,7 @@ class GripperClient extends Gripper implements ResourceRPCClient {
     final request = DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 }

--- a/lib/src/components/motor/client.dart
+++ b/lib/src/components/motor/client.dart
@@ -9,7 +9,7 @@ import 'motor.dart';
 
 /// {@category Components}
 /// gRPC client for the [Motor] component.
-class MotorClient extends Motor implements ResourceRPCClient {
+class MotorClient extends Motor with RPCDebugLoggerMixin implements ResourceRPCClient {
   @override
   final String name;
 
@@ -27,7 +27,7 @@ class MotorClient extends Motor implements ResourceRPCClient {
       ..name = name
       ..powerPct = powerPct
       ..extra = extra?.toStruct() ?? Struct();
-    await client.setPower(request);
+    await client.setPower(request, options: callOptions);
   }
 
   @override
@@ -37,7 +37,7 @@ class MotorClient extends Motor implements ResourceRPCClient {
       ..rpm = rpm
       ..revolutions = revolutions
       ..extra = extra?.toStruct() ?? Struct();
-    await client.goFor(request);
+    await client.goFor(request, options: callOptions);
   }
 
   @override
@@ -47,7 +47,7 @@ class MotorClient extends Motor implements ResourceRPCClient {
       ..rpm = rpm
       ..positionRevolutions = positionRevolutions
       ..extra = extra?.toStruct() ?? Struct();
-    await client.goTo(request);
+    await client.goTo(request, options: callOptions);
   }
 
   @override
@@ -56,7 +56,7 @@ class MotorClient extends Motor implements ResourceRPCClient {
       ..name = name
       ..rpm = rpm
       ..extra = extra?.toStruct() ?? Struct();
-    await client.setRPM(request);
+    await client.setRPM(request, options: callOptions);
   }
 
   @override
@@ -65,7 +65,7 @@ class MotorClient extends Motor implements ResourceRPCClient {
       ..name = name
       ..offset = offset
       ..extra = extra?.toStruct() ?? Struct();
-    await client.resetZeroPosition(request);
+    await client.resetZeroPosition(request, options: callOptions);
   }
 
   @override
@@ -73,7 +73,7 @@ class MotorClient extends Motor implements ResourceRPCClient {
     final request = GetPositionRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final result = await client.getPosition(request);
+    final result = await client.getPosition(request, options: callOptions);
     return result.position;
   }
 
@@ -82,7 +82,7 @@ class MotorClient extends Motor implements ResourceRPCClient {
     final request = GetPropertiesRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    return await client.getProperties(request);
+    return await client.getProperties(request, options: callOptions);
   }
 
   @override
@@ -90,7 +90,7 @@ class MotorClient extends Motor implements ResourceRPCClient {
     final request = StopRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    await client.stop(request);
+    await client.stop(request, options: callOptions);
   }
 
   @override
@@ -98,14 +98,14 @@ class MotorClient extends Motor implements ResourceRPCClient {
     final request = IsPoweredRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final result = await client.isPowered(request);
+    final result = await client.isPowered(request, options: callOptions);
     return PowerState.fromProto(result);
   }
 
   @override
   Future<bool> isMoving({Map<String, dynamic>? extra}) async {
     final request = IsMovingRequest()..name = name;
-    final result = await client.isMoving(request);
+    final result = await client.isMoving(request, options: callOptions);
     return result.isMoving;
   }
 
@@ -114,7 +114,7 @@ class MotorClient extends Motor implements ResourceRPCClient {
     final request = DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 }

--- a/lib/src/components/movement_sensor/client.dart
+++ b/lib/src/components/movement_sensor/client.dart
@@ -9,7 +9,7 @@ import 'movement_sensor.dart';
 
 /// {@category Components}
 /// gRPC client for the [MovementSensor] component.
-class MovementSensorClient extends MovementSensor implements ResourceRPCClient {
+class MovementSensorClient extends MovementSensor with RPCDebugLoggerMixin implements ResourceRPCClient {
   @override
   final String name;
 
@@ -26,7 +26,7 @@ class MovementSensorClient extends MovementSensor implements ResourceRPCClient {
     final request = GetReadingsRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getReadings(request);
+    final response = await client.getReadings(request, options: callOptions);
     return response.toPrimitive();
   }
 
@@ -35,7 +35,7 @@ class MovementSensorClient extends MovementSensor implements ResourceRPCClient {
     final request = GetPositionRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getPosition(request);
+    final response = await client.getPosition(request, options: callOptions);
     return Position(response.coordinate, response.altitudeM);
   }
 
@@ -44,7 +44,7 @@ class MovementSensorClient extends MovementSensor implements ResourceRPCClient {
     final request = GetLinearVelocityRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getLinearVelocity(request);
+    final response = await client.getLinearVelocity(request, options: callOptions);
     return response.linearVelocity;
   }
 
@@ -53,7 +53,7 @@ class MovementSensorClient extends MovementSensor implements ResourceRPCClient {
     final request = GetAngularVelocityRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getAngularVelocity(request);
+    final response = await client.getAngularVelocity(request, options: callOptions);
     return response.angularVelocity;
   }
 
@@ -62,7 +62,7 @@ class MovementSensorClient extends MovementSensor implements ResourceRPCClient {
     final request = GetLinearAccelerationRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getLinearAcceleration(request);
+    final response = await client.getLinearAcceleration(request, options: callOptions);
     return response.linearAcceleration;
   }
 
@@ -80,7 +80,7 @@ class MovementSensorClient extends MovementSensor implements ResourceRPCClient {
     final request = GetOrientationRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getOrientation(request);
+    final response = await client.getOrientation(request, options: callOptions);
     return response.orientation;
   }
 
@@ -89,7 +89,7 @@ class MovementSensorClient extends MovementSensor implements ResourceRPCClient {
     final request = GetPropertiesRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    return await client.getProperties(request);
+    return await client.getProperties(request, options: callOptions);
   }
 
   @override
@@ -97,7 +97,7 @@ class MovementSensorClient extends MovementSensor implements ResourceRPCClient {
     final request = GetAccuracyRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    return await client.getAccuracy(request);
+    return await client.getAccuracy(request, options: callOptions);
   }
 
   @override
@@ -105,7 +105,7 @@ class MovementSensorClient extends MovementSensor implements ResourceRPCClient {
     final request = DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 }

--- a/lib/src/components/power_sensor/client.dart
+++ b/lib/src/components/power_sensor/client.dart
@@ -9,7 +9,7 @@ import 'power_sensor.dart';
 
 /// {@category Components}
 /// gRPC client for the [PowerSensor] component.
-class PowerSensorClient extends PowerSensor implements ResourceRPCClient {
+class PowerSensorClient extends PowerSensor with RPCDebugLoggerMixin implements ResourceRPCClient {
   @override
   final String name;
 
@@ -26,7 +26,7 @@ class PowerSensorClient extends PowerSensor implements ResourceRPCClient {
     final request = GetReadingsRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getReadings(request);
+    final response = await client.getReadings(request, options: callOptions);
     return response.readings.map((key, value) => MapEntry(key, value.toPrimitive()));
   }
 
@@ -35,7 +35,7 @@ class PowerSensorClient extends PowerSensor implements ResourceRPCClient {
     final request = GetVoltageRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    return await client.getVoltage(request);
+    return await client.getVoltage(request, options: callOptions);
   }
 
   @override
@@ -43,7 +43,7 @@ class PowerSensorClient extends PowerSensor implements ResourceRPCClient {
     final request = GetCurrentRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    return await client.getCurrent(request);
+    return await client.getCurrent(request, options: callOptions);
   }
 
   @override
@@ -51,7 +51,7 @@ class PowerSensorClient extends PowerSensor implements ResourceRPCClient {
     final request = GetPowerRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getPower(request);
+    final response = await client.getPower(request, options: callOptions);
     return response.watts;
   }
 
@@ -60,7 +60,7 @@ class PowerSensorClient extends PowerSensor implements ResourceRPCClient {
     final request = DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 }

--- a/lib/src/components/sensor/client.dart
+++ b/lib/src/components/sensor/client.dart
@@ -9,7 +9,7 @@ import 'sensor.dart';
 
 /// {@category Components}
 /// gRPC client for the [Sensor] component.
-class SensorClient extends Sensor implements ResourceRPCClient {
+class SensorClient extends Sensor with RPCDebugLoggerMixin implements ResourceRPCClient {
   @override
   final String name;
 
@@ -26,7 +26,7 @@ class SensorClient extends Sensor implements ResourceRPCClient {
     final request = GetReadingsRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getReadings(request);
+    final response = await client.getReadings(request, options: callOptions);
     return response.toPrimitive();
   }
 
@@ -35,7 +35,7 @@ class SensorClient extends Sensor implements ResourceRPCClient {
     final request = DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 }

--- a/lib/src/components/servo/client.dart
+++ b/lib/src/components/servo/client.dart
@@ -9,7 +9,7 @@ import 'servo.dart';
 
 /// {@category Components}
 /// gRPC client for the [Servo] component.
-class ServoClient extends Servo implements ResourceRPCClient {
+class ServoClient extends Servo with RPCDebugLoggerMixin implements ResourceRPCClient {
   @override
   final String name;
 
@@ -35,7 +35,7 @@ class ServoClient extends Servo implements ResourceRPCClient {
     final request = GetPositionRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getPosition(request);
+    final response = await client.getPosition(request, options: callOptions);
     return response.positionDeg;
   }
 
@@ -50,7 +50,7 @@ class ServoClient extends Servo implements ResourceRPCClient {
   @override
   Future<bool> isMoving({Map<String, dynamic>? extra}) async {
     final request = IsMovingRequest()..name = name;
-    final response = await client.isMoving(request);
+    final response = await client.isMoving(request, options: callOptions);
     return response.isMoving;
   }
 
@@ -59,7 +59,7 @@ class ServoClient extends Servo implements ResourceRPCClient {
     final request = DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 }

--- a/lib/src/components/switch/client.dart
+++ b/lib/src/components/switch/client.dart
@@ -9,7 +9,7 @@ import 'switch.dart';
 
 /// {@category Components}
 /// gRPC client for the [Switch] component.
-class SwitchClient extends Switch implements ResourceRPCClient {
+class SwitchClient extends Switch with RPCDebugLoggerMixin implements ResourceRPCClient {
   @override
   final String name;
 
@@ -27,7 +27,7 @@ class SwitchClient extends Switch implements ResourceRPCClient {
       ..name = name
       ..position = position
       ..extra = extra?.toStruct() ?? Struct();
-    await client.setPosition(request);
+    await client.setPosition(request, options: callOptions);
   }
 
   @override
@@ -35,7 +35,7 @@ class SwitchClient extends Switch implements ResourceRPCClient {
     final request = GetPositionRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getPosition(request);
+    final response = await client.getPosition(request, options: callOptions);
     return response.position;
   }
 
@@ -44,7 +44,7 @@ class SwitchClient extends Switch implements ResourceRPCClient {
     final request = GetNumberOfPositionsRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    final response = await client.getNumberOfPositions(request);
+    final response = await client.getNumberOfPositions(request, options: callOptions);
     return response.numberOfPositions;
   }
 
@@ -53,7 +53,7 @@ class SwitchClient extends Switch implements ResourceRPCClient {
     final request = DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 }

--- a/lib/src/resource/base.dart
+++ b/lib/src/resource/base.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:math';
+
 import 'package:grpc/grpc.dart';
 import 'package:grpc/grpc_connection_interface.dart';
 
@@ -90,4 +93,29 @@ abstract class ResourceRPCClient<T extends Client> {
   abstract ClientChannelBase channel;
 
   T get client;
+}
+
+/// {@category Viam SDK}
+/// Mixin that provides debug logging functionality for gRPC calls
+mixin RPCDebugLoggerMixin {
+  CallOptions get callOptions => _callOptions;
+  CallOptions _callOptions = CallOptions();
+
+  /// Enable debug logging for gRPC calls by setting a trace key in the metadata.
+  /// If no trace key is provided, a random one will be generated.
+  void enableDebugLogging({String? traceKey}) {
+    traceKey ??= _generateRandomString();
+    _callOptions = CallOptions(metadata: {'dtname': traceKey});
+  }
+
+  /// Disable debug logging for gRPC calls by removing the trace key from the metadata.
+  void disableDebugLogging() {
+    _callOptions = CallOptions();
+  }
+
+  String _generateRandomString({int length = 6}) {
+    const _chars = 'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890';
+    Random _rnd = Random();
+    return String.fromCharCodes(Iterable.generate(length, (_) => _chars.codeUnitAt(_rnd.nextInt(_chars.length))));
+  }
 }

--- a/lib/src/services/discovery.dart
+++ b/lib/src/services/discovery.dart
@@ -10,7 +10,7 @@ import '../robot/client.dart';
 import '../utils.dart';
 
 /// {@category Services}
-class DiscoveryClient extends Resource implements ResourceRPCClient {
+class DiscoveryClient extends Resource with RPCDebugLoggerMixin implements ResourceRPCClient {
   static const Subtype subtype = Subtype(resourceNamespaceRDK, resourceTypeService, 'discovery');
 
   @override
@@ -32,7 +32,7 @@ class DiscoveryClient extends Resource implements ResourceRPCClient {
   /// ```
   Future<List<ComponentConfig>> discoverResources({Map<String, dynamic>? extra}) async {
     final request = DiscoverResourcesRequest(name: name, extra: extra?.toStruct());
-    final response = await client.discoverResources(request);
+    final response = await client.discoverResources(request, options: callOptions);
     return response.discoveries;
   }
 
@@ -41,7 +41,7 @@ class DiscoveryClient extends Resource implements ResourceRPCClient {
     final request = DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 

--- a/lib/src/services/vision.dart
+++ b/lib/src/services/vision.dart
@@ -13,7 +13,7 @@ import '../utils.dart';
 typedef VisionProperties = GetPropertiesResponse;
 
 /// {@category Services}
-class VisionClient extends Resource implements ResourceRPCClient {
+class VisionClient extends Resource with RPCDebugLoggerMixin implements ResourceRPCClient {
   static const Subtype subtype = Subtype(resourceNamespaceRDK, resourceTypeService, 'vision');
 
   @override
@@ -37,7 +37,7 @@ class VisionClient extends Resource implements ResourceRPCClient {
   /// For more information, see the [vision service docs](https://docs.viam.com/dev/reference/apis/services/vision/#getdetectionsfromcamera).
   Future<List<Detection>> detectionsFromCamera(String cameraName, {Map<String, dynamic>? extra}) async {
     final request = GetDetectionsFromCameraRequest(name: name, cameraName: cameraName, extra: extra?.toStruct());
-    final response = await client.getDetectionsFromCamera(request);
+    final response = await client.getDetectionsFromCamera(request, options: callOptions);
     return response.detections;
   }
 
@@ -57,7 +57,7 @@ class VisionClient extends Resource implements ResourceRPCClient {
         height: Int64(image.image?.height ?? 0),
         mimeType: image.mimeType.name,
         extra: extra?.toStruct());
-    final response = await client.getDetections(request);
+    final response = await client.getDetections(request, options: callOptions);
     return response.detections;
   }
 
@@ -72,7 +72,7 @@ class VisionClient extends Resource implements ResourceRPCClient {
   /// For more information, see the [vision service docs](https://docs.viam.com/dev/reference/apis/services/vision/#getclassificationsfromcamera).
   Future<List<Classification>> classificationsFromCamera(String cameraName, int count, {Map<String, dynamic>? extra}) async {
     final request = GetClassificationsFromCameraRequest(name: name, cameraName: cameraName, n: count, extra: extra?.toStruct());
-    final response = await client.getClassificationsFromCamera(request);
+    final response = await client.getClassificationsFromCamera(request, options: callOptions);
     return response.classifications;
   }
 
@@ -95,7 +95,7 @@ class VisionClient extends Resource implements ResourceRPCClient {
         mimeType: image.mimeType.name,
         n: count,
         extra: extra?.toStruct());
-    final response = await client.getClassifications(request);
+    final response = await client.getClassifications(request, options: callOptions);
     return response.classifications;
   }
 
@@ -109,7 +109,7 @@ class VisionClient extends Resource implements ResourceRPCClient {
   /// For more information, see the [vision service docs](https://docs.viam.com/dev/reference/apis/services/vision/#getobjectpointclouds).
   Future<List<PointCloudObject>> objectPointClouds(String cameraName, {Map<String, dynamic>? extra}) async {
     final request = GetObjectPointCloudsRequest(name: name, cameraName: cameraName, mimeType: MimeType.pcd.name, extra: extra?.toStruct());
-    final response = await client.getObjectPointClouds(request);
+    final response = await client.getObjectPointClouds(request, options: callOptions);
     return response.objects;
   }
 
@@ -127,7 +127,7 @@ class VisionClient extends Resource implements ResourceRPCClient {
   /// For more information, see the [vision service docs](https://docs.viam.com/dev/reference/apis/services/vision/#getproperties).
   Future<VisionProperties> properties({Map<String, dynamic>? extra}) async {
     final request = GetPropertiesRequest(name: name, extra: extra?.toStruct());
-    return await client.getProperties(request);
+    return await client.getProperties(request, options: callOptions);
   }
 
   @override
@@ -135,7 +135,7 @@ class VisionClient extends Resource implements ResourceRPCClient {
     final request = DoCommandRequest()
       ..name = name
       ..command = command.toStruct();
-    final response = await client.doCommand(request);
+    final response = await client.doCommand(request, options: callOptions);
     return response.result.toMap();
   }
 

--- a/test/unit_test/mocks/service_clients_mocks.mocks.dart
+++ b/test/unit_test/mocks/service_clients_mocks.mocks.dart
@@ -1306,6 +1306,39 @@ class MockAppServiceClient extends _i1.Mock implements _i12.AppServiceClient {
           as _i4.ResponseFuture<_i13.UpdateOrganizationResponse>);
 
   @override
+  _i4.ResponseFuture<_i13.UpdateOrganizationNamespaceResponse>
+  updateOrganizationNamespace(
+    _i13.UpdateOrganizationNamespaceRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #updateOrganizationNamespace,
+              [request],
+              {#options: options},
+            ),
+            returnValue:
+                _FakeResponseFuture_2<_i13.UpdateOrganizationNamespaceResponse>(
+                  this,
+                  Invocation.method(
+                    #updateOrganizationNamespace,
+                    [request],
+                    {#options: options},
+                  ),
+                ),
+            returnValueForMissingStub:
+                _FakeResponseFuture_2<_i13.UpdateOrganizationNamespaceResponse>(
+                  this,
+                  Invocation.method(
+                    #updateOrganizationNamespace,
+                    [request],
+                    {#options: options},
+                  ),
+                ),
+          )
+          as _i4.ResponseFuture<_i13.UpdateOrganizationNamespaceResponse>);
+
+  @override
   _i4.ResponseFuture<_i13.DeleteOrganizationResponse> deleteOrganization(
     _i13.DeleteOrganizationRequest? request, {
     _i3.CallOptions? options,
@@ -3142,6 +3175,38 @@ class MockAppServiceClient extends _i1.Mock implements _i12.AppServiceClient {
           as _i4.ResponseFuture<_i13.DeleteFragmentResponse>);
 
   @override
+  _i4.ResponseFuture<_i13.ListNestedFragmentsResponse> listNestedFragments(
+    _i13.ListNestedFragmentsRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #listNestedFragments,
+              [request],
+              {#options: options},
+            ),
+            returnValue:
+                _FakeResponseFuture_2<_i13.ListNestedFragmentsResponse>(
+                  this,
+                  Invocation.method(
+                    #listNestedFragments,
+                    [request],
+                    {#options: options},
+                  ),
+                ),
+            returnValueForMissingStub:
+                _FakeResponseFuture_2<_i13.ListNestedFragmentsResponse>(
+                  this,
+                  Invocation.method(
+                    #listNestedFragments,
+                    [request],
+                    {#options: options},
+                  ),
+                ),
+          )
+          as _i4.ResponseFuture<_i13.ListNestedFragmentsResponse>);
+
+  @override
   _i4.ResponseFuture<_i13.ListMachineFragmentsResponse> listMachineFragments(
     _i13.ListMachineFragmentsRequest? request, {
     _i3.CallOptions? options,
@@ -3602,6 +3667,37 @@ class MockAppServiceClient extends _i1.Mock implements _i12.AppServiceClient {
                 ),
           )
           as _i4.ResponseFuture<_i13.DeleteRegistryItemResponse>);
+
+  @override
+  _i4.ResponseFuture<_i13.RenameRegistryItemResponse> renameRegistryItem(
+    _i13.RenameRegistryItemRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #renameRegistryItem,
+              [request],
+              {#options: options},
+            ),
+            returnValue: _FakeResponseFuture_2<_i13.RenameRegistryItemResponse>(
+              this,
+              Invocation.method(
+                #renameRegistryItem,
+                [request],
+                {#options: options},
+              ),
+            ),
+            returnValueForMissingStub:
+                _FakeResponseFuture_2<_i13.RenameRegistryItemResponse>(
+                  this,
+                  Invocation.method(
+                    #renameRegistryItem,
+                    [request],
+                    {#options: options},
+                  ),
+                ),
+          )
+          as _i4.ResponseFuture<_i13.RenameRegistryItemResponse>);
 
   @override
   _i4.ResponseFuture<_i13.TransferRegistryItemResponse> transferRegistryItem(
@@ -5541,6 +5637,74 @@ class MockBillingServiceClient extends _i1.Mock
                 ),
           )
           as _i4.ResponseFuture<_i22.SendPaymentRequiredEmailResponse>);
+
+  @override
+  _i4.ResponseFuture<_i22.GetAvailableBillingTiersResponse>
+  getAvailableBillingTiers(
+    _i22.GetAvailableBillingTiersRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #getAvailableBillingTiers,
+              [request],
+              {#options: options},
+            ),
+            returnValue:
+                _FakeResponseFuture_2<_i22.GetAvailableBillingTiersResponse>(
+                  this,
+                  Invocation.method(
+                    #getAvailableBillingTiers,
+                    [request],
+                    {#options: options},
+                  ),
+                ),
+            returnValueForMissingStub:
+                _FakeResponseFuture_2<_i22.GetAvailableBillingTiersResponse>(
+                  this,
+                  Invocation.method(
+                    #getAvailableBillingTiers,
+                    [request],
+                    {#options: options},
+                  ),
+                ),
+          )
+          as _i4.ResponseFuture<_i22.GetAvailableBillingTiersResponse>);
+
+  @override
+  _i4.ResponseFuture<_i22.UpdateOrganizationBillingTierResponse>
+  updateOrganizationBillingTier(
+    _i22.UpdateOrganizationBillingTierRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #updateOrganizationBillingTier,
+              [request],
+              {#options: options},
+            ),
+            returnValue: _FakeResponseFuture_2<
+              _i22.UpdateOrganizationBillingTierResponse
+            >(
+              this,
+              Invocation.method(
+                #updateOrganizationBillingTier,
+                [request],
+                {#options: options},
+              ),
+            ),
+            returnValueForMissingStub: _FakeResponseFuture_2<
+              _i22.UpdateOrganizationBillingTierResponse
+            >(
+              this,
+              Invocation.method(
+                #updateOrganizationBillingTier,
+                [request],
+                {#options: options},
+              ),
+            ),
+          )
+          as _i4.ResponseFuture<_i22.UpdateOrganizationBillingTierResponse>);
 
   @override
   _i3.ClientCall<Q, R> $createCall<Q, R>(

--- a/test/unit_test/services/discovery_test.dart
+++ b/test/unit_test/services/discovery_test.dart
@@ -29,7 +29,7 @@ void main() {
   group('Discovery RPC Client Tests', () {
     test('discoverResources', () async {
       final expected = [ComponentConfig()];
-      when(serviceClient.discoverResources(any))
+      when(serviceClient.discoverResources(any, options: anyNamed('options')))
           .thenAnswer((_) => MockResponseFuture.value(DiscoverResourcesResponse(discoveries: expected)));
       final response = await client.discoverResources();
       expect(response, equals(expected));

--- a/test/unit_test/services/vision_test.dart
+++ b/test/unit_test/services/vision_test.dart
@@ -30,7 +30,7 @@ void main() {
   group('Vision RPC Client Tests', () {
     test('getDetectionsFromCamera', () async {
       final expected = [Detection(xMin: Int64(1), xMax: Int64(2), yMin: Int64(3), yMax: Int64(4), confidence: 0.95, className: 'test')];
-      when(serviceClient.getDetectionsFromCamera(any))
+      when(serviceClient.getDetectionsFromCamera(any, options: anyNamed('options')))
           .thenAnswer((_) => MockResponseFuture.value(GetDetectionsFromCameraResponse(detections: expected)));
       final response = await client.detectionsFromCamera('cameraName');
       expect(response, equals(expected));
@@ -38,14 +38,15 @@ void main() {
 
     test('getDetections', () async {
       final expected = [Detection(xMin: Int64(1), xMax: Int64(2), yMin: Int64(3), yMax: Int64(4), confidence: 0.95, className: 'test')];
-      when(serviceClient.getDetections(any)).thenAnswer((_) => MockResponseFuture.value(GetDetectionsResponse(detections: expected)));
+      when(serviceClient.getDetections(any, options: anyNamed('options')))
+          .thenAnswer((_) => MockResponseFuture.value(GetDetectionsResponse(detections: expected)));
       final response = await client.detections(ViamImage([1, 2, 3], const MimeType.unsupported('fake')));
       expect(response, equals(expected));
     });
 
     test('getClassificationsFromCamera', () async {
       final expected = [Classification(className: 'test-classification', confidence: 0.44)];
-      when(serviceClient.getClassificationsFromCamera(any))
+      when(serviceClient.getClassificationsFromCamera(any, options: anyNamed('options')))
           .thenAnswer((_) => MockResponseFuture.value(GetClassificationsFromCameraResponse(classifications: expected)));
       final response = await client.classificationsFromCamera('cameraName', 2);
       expect(response, equals(expected));
@@ -53,7 +54,7 @@ void main() {
 
     test('getClassifications', () async {
       final expected = [Classification(className: 'test-classification', confidence: 0.44)];
-      when(serviceClient.getClassifications(any))
+      when(serviceClient.getClassifications(any, options: anyNamed('options')))
           .thenAnswer((_) => MockResponseFuture.value(GetClassificationsResponse(classifications: expected)));
       final response = await client.classifications(ViamImage([1, 2, 3], const MimeType.unsupported('fake')), 2);
       expect(response, equals(expected));
@@ -61,7 +62,7 @@ void main() {
 
     test('properties', () async {
       final expected = GetPropertiesResponse(classificationsSupported: true);
-      when(serviceClient.getProperties(any)).thenAnswer((_) => MockResponseFuture.value(expected));
+      when(serviceClient.getProperties(any, options: anyNamed('options'))).thenAnswer((_) => MockResponseFuture.value(expected));
       final response = await client.properties();
       expect(response, equals(expected));
     });
@@ -80,7 +81,7 @@ void main() {
           ),
         ),
       ];
-      when(serviceClient.getObjectPointClouds(any))
+      when(serviceClient.getObjectPointClouds(any, options: anyNamed('options')))
           .thenAnswer((_) => MockResponseFuture.value(GetObjectPointCloudsResponse(objects: expected, mimeType: MimeType.pcd.name)));
       final response = await client.objectPointClouds('cameraName');
       expect(response, equals(expected));


### PR DESCRIPTION
Add trace debug logging. You can enable/disable trace logging by calling `enableDebugLogging` or `disableDebugLogging` on a client.

Caveat: You have to do it on a client. When you call `fromRobot`, you get the base class back. So you'll have to cast it.

```dart
final myArm = Arm.fromRobot(robot, "my-arm");
final armClient = myArm as ArmClient;
armClient.enableDebugLogging(traceKey: "arm-logger");
await armClient.move()
armClient.disableDebugLogging()
```

Got inspiration from
https://github.com/viamrobotics/viam-python-sdk/pull/747
https://github.com/viamrobotics/viam-typescript-sdk/pull/384