### PR TITLE
Hardcode ip for provisioning, fix client used with apikey

### DIFF
--- a/lib/src/app/provisioning.dart
+++ b/lib/src/app/provisioning.dart
@@ -7,8 +7,6 @@ enum NetworkType { wifi, wired }
 
 /// {@category Viam SDK}
 /// gRPC client for connecting to Viam's Provisioning Service
-///
-/// All calls must be authenticated.
 class ProvisioningClient {
   final ProvisioningServiceClient _client;
 

--- a/lib/src/viam_sdk_impl.dart
+++ b/lib/src/viam_sdk_impl.dart
@@ -31,7 +31,14 @@ class ViamImpl implements Viam {
     _billingClient = BillingClient(BillingServiceClient(_clientChannelBase));
     _dataClient = DataClient(
         DataServiceClient(_clientChannelBase), DataSyncServiceClient(_clientChannelBase), DatasetServiceClient(_clientChannelBase));
-    _provisioningClient = ProvisioningClient(ProvisioningServiceClient(ClientChannel('provisioning.viam', port: 4772)));
+
+    _provisioningClient = ProvisioningClient(ProvisioningServiceClient(
+      ClientChannel(
+        'viam.setup',
+        port: 4772,
+        options: const ChannelOptions(credentials: ChannelCredentials.insecure()),
+      ),
+    ));
   }
 
   ViamImpl.withAccessToken(String accessToken, {String serviceHost = 'app.viam.com', int servicePort = 443})

--- a/lib/src/viam_sdk_impl.dart
+++ b/lib/src/viam_sdk_impl.dart
@@ -34,7 +34,7 @@ class ViamImpl implements Viam {
 
     _provisioningClient = ProvisioningClient(ProvisioningServiceClient(
       ClientChannel(
-        'viam.setup',
+        '10.42.0.1',
         port: 4772,
         options: const ChannelOptions(credentials: ChannelCredentials.insecure()),
       ),
@@ -51,7 +51,7 @@ class ViamImpl implements Viam {
 
     _provisioningClient = ProvisioningClient(ProvisioningServiceClient(
       ClientChannel(
-        'viam.setup',
+        '10.42.0.1',
         port: 4772,
         options: const ChannelOptions(credentials: ChannelCredentials.insecure()),
       ),


### PR DESCRIPTION
Updates to use the ip `10.42.0.1` instead of a hostname `viam.setup` during provisioning. Using `viam.setup` while using cellular (but connected to the hotspot) on iOS does not work and the requests fail.

Also,

Testing in my [example project](https://github.com/viamrobotics/viam_flutter_provisioning_widget/tree/main/example/hotspot_provisioning), I couldn't get the init w/ api key to function (for provisioning): https://github.com/viamrobotics/viam_flutter_provisioning_widget/pull/2

I think the host `provisioning.viam` in this init for the `ProvisioningClient` is outdated / doesn't match how it's setup when using an access token (uses `viam.setup`). Plus we want to use an ip now here as well