### PR TITLE
Add GetMachineStatus to RobotClient

### DIFF
--- a/lib/src/robot/client.dart
+++ b/lib/src/robot/client.dart
@@ -303,4 +303,15 @@ class RobotClient {
     final response = await _client.getModelsFromModules(request);
     return response.models;
   }
+
+  /// GetMachineStatus returns status of the machine and its resources.
+  ///
+  /// ```
+  /// var machineStatus = await machine.getMachineStatus();
+  /// ```
+  Future<GetMachineStatusResponse> getMachineStatus() async {
+    final request = rpb.GetMachineStatusRequest();
+    final response = await _client.getMachineStatus(request);
+    return response;
+  }
 }


### PR DESCRIPTION
This request can be useful in the mobile apps for checking when added/removed cameras, sensors, other resources are [available or removed](https://github.com/viamrobotics/viam-flutter-sdk/blob/5e1c35c4c45ad0c939a3eb29af8fb8ee38d4d917/lib/src/gen/robot/v1/robot.pbenum.dart#L50) so we can communicate that better to users. 

May be better than calling [refresh](https://github.com/viamrobotics/viam-flutter-sdk/blob/5e1c35c4c45ad0c939a3eb29af8fb8ee38d4d917/lib/src/robot/client.dart#L115) and continuously checking for resources to be present there.