### PR TITLE
Add sendEmailInvite parameter to resendOrganizationInvite

### DIFF
--- a/lib/src/app/app.dart
+++ b/lib/src/app/app.dart
@@ -186,10 +186,11 @@ class AppClient {
   /// Resend an invite to an [Organization]
   ///
   /// For more information, see [Fleet Management API](https://docs.viam.com/appendix/apis/fleet/).
-  Future<OrganizationInvite> resendOrganizationInvite(String organizationId, String email) async {
+  Future<OrganizationInvite> resendOrganizationInvite(String organizationId, String email, {bool sendEmailInvite = true}) async {
     final request = ResendOrganizationInviteRequest()
       ..organizationId = organizationId
-      ..email = email;
+      ..email = email
+      ..sendEmailInvite = sendEmailInvite;
     final ResendOrganizationInviteResponse response = await _client.resendOrganizationInvite(request);
     return response.invite;
   }

--- a/test/unit_test/app/app_client_test.dart
+++ b/test/unit_test/app/app_client_test.dart
@@ -195,7 +195,7 @@ void main() {
         ..createdOn = Timestamp.create();
       when(serviceClient.resendOrganizationInvite(any))
           .thenAnswer((_) => MockResponseFuture.value(ResendOrganizationInviteResponse()..invite = expected));
-      final response = await appClient.resendOrganizationInvite('organizationId', 'email');
+      final response = await appClient.resendOrganizationInvite('organizationId', 'email', sendEmailInvite: true);
       expect(response, equals(expected));
     });
 


### PR DESCRIPTION
Add a sendEmailInvite boolean to the resendOrganizationInvite() method, allowing us to control whether an email invite is sent when the invite is resent