### PR TITLE
[RSDK-10907] Flutter SDK - Switch widget hits assert on first build

### DIFF
--- a/lib/widgets/resources/switch.dart
+++ b/lib/widgets/resources/switch.dart
@@ -17,7 +17,7 @@ class ViamSwitchWidget extends StatefulWidget {
 class _ViamSwitchWidgetState extends State<ViamSwitchWidget> {
   int position = 0;
   String newPosition = '0';
-  int numberOfPositions = 0;
+  int? numberOfPositions;
   Error? error;
 
   @override
@@ -78,6 +78,10 @@ class _ViamSwitchWidgetState extends State<ViamSwitchWidget> {
 
   @override
   Widget build(BuildContext context) {
+    if (numberOfPositions == null) {
+      return const Text('Loading...');
+    }
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -85,9 +89,9 @@ class _ViamSwitchWidgetState extends State<ViamSwitchWidget> {
           data: _sliderTheme,
           child: Slider(
             value: position.toDouble(),
-            max: numberOfPositions - 1.0,
+            max: numberOfPositions! - 1.0,
             min: 0.0,
-            divisions: numberOfPositions - 1,
+            divisions: numberOfPositions! - 1,
             label: '$position',
             onChanged: (double value) => _setPosition(value.toInt()),
           ),


### PR DESCRIPTION
Fixed assert so there is no error when switch widget first builds

Tested on ios:

https://github.com/user-attachments/assets/77fe9604-d730-4138-9e83-d9c5b411c781


Tested on android:


https://github.com/user-attachments/assets/4c5e5bc9-a8e2-460a-9d30-ce36146eb85e

