### PR TITLE
RSDK-11707    —     Update Flutter SDK with new GetImages signature

### DIFF
--- a/lib/src/components/camera/camera.dart
+++ b/lib/src/components/camera/camera.dart
@@ -5,6 +5,47 @@ import '../../resource/base.dart';
 import '../../robot/client.dart';
 
 /// {@category Viam SDK}
+/// A ViamImage with its source name from the camera
+class NamedImage {
+  /// Name of the source where the image came from
+  final String sourceName;
+
+  /// ViamImage that contains the mime type and raw image data
+  final ViamImage image;
+
+  NamedImage({
+    required this.sourceName,
+    required this.image,
+  });
+}
+
+/// {@category Viam SDK}
+/// Metadata about a GetImages response
+class ResponseMetadata {
+  /// Timestamp of when the response was captured
+  final DateTime capturedAt;
+
+  ResponseMetadata({
+    required this.capturedAt,
+  });
+}
+
+/// {@category Viam SDK}
+/// Response from GetImages containing named images and metadata
+class GetImagesResult {
+  /// The list of named images from various sources
+  final List<NamedImage> images;
+
+  /// Metadata about the response
+  final ResponseMetadata? metadata;
+
+  GetImagesResult({
+    required this.images,
+    this.metadata,
+  });
+}
+
+/// {@category Viam SDK}
 /// The camera's supported features and settings
 typedef CameraProperties = GetPropertiesResponse;
 
@@ -41,6 +82,29 @@ abstract class Camera extends Resource {
   ///
   /// For more information, see [Camera component](https://docs.viam.com/dev/reference/apis/components/camera/#getproperties).
   Future<CameraProperties> properties();
+
+  /// Return a list of named images from a camera and metadata about the response.
+  ///
+  /// ```
+  /// const camera = new VIAM.CameraClient(machine, 'my_camera');
+  /// const images = await camera.getImages();
+  /// ```
+  ///
+  /// @example
+  /// ```
+  /// final images = await camera.getImages(
+  ///   filterSourceNames: ['color'],
+  ///   extra: {},
+  /// );
+  /// ```
+  ///
+  /// @param filterSourceNames - A list of source names to filter the images by.
+  ///                           If empty or undefined, all images will be returned.
+  /// @param extra - Extra parameters to pass to the camera.
+  Future<GetImagesResult> getImages({
+    List<String>? filterSourceNames,
+    Map<String, dynamic>? extra,
+  });
 
   /// Get the [ResourceName] for this [Camera] with the given [name]
   ///

--- a/lib/src/components/camera/service.dart
+++ b/lib/src/components/camera/service.dart
@@ -1,8 +1,9 @@
 import 'package:grpc/grpc.dart';
 
-import '../../gen/common/v1/common.pb.dart';
+import '../../gen/common/v1/common.pb.dart' as proto;
 import '../../gen/component/camera/v1/camera.pbgrpc.dart';
 import '../../gen/google/api/httpbody.pb.dart';
+import '../../gen/google/protobuf/timestamp.pb.dart';
 import '../../media/image.dart';
 import '../../resource/manager.dart';
 import '../../utils.dart';
@@ -24,10 +25,10 @@ class CameraService extends CameraServiceBase {
   }
 
   @override
-  Future<DoCommandResponse> doCommand(ServiceCall call, DoCommandRequest request) async {
+  Future<proto.DoCommandResponse> doCommand(ServiceCall call, proto.DoCommandRequest request) async {
     final camera = _fromManager(request.name);
     final result = await camera.doCommand(request.command.toMap());
-    return DoCommandResponse()..result = result.toStruct();
+    return proto.DoCommandResponse()..result = result.toStruct();
   }
 
   @override
@@ -65,14 +66,51 @@ class CameraService extends CameraServiceBase {
   }
 
   @override
-  Future<GetGeometriesResponse> getGeometries(ServiceCall call, GetGeometriesRequest request) {
+  Future<proto.GetGeometriesResponse> getGeometries(ServiceCall call, proto.GetGeometriesRequest request) {
     // TODO: implement getGeometries
     throw UnimplementedError();
   }
 
   @override
-  Future<GetImagesResponse> getImages(ServiceCall call, GetImagesRequest request) {
-    // TODO: implement getImages
-    throw UnimplementedError();
+  Future<GetImagesResponse> getImages(ServiceCall call, GetImagesRequest request) async {
+    final camera = _fromManager(request.name);
+    final result = await camera.getImages(
+      filterSourceNames: request.filterSourceNames,
+      extra: request.extra.toMap(),
+    );
+    final response = GetImagesResponse();
+
+    for (final namedImage in result.images) {
+      final protoImage = Image()
+        ..sourceName = namedImage.sourceName
+        ..image = namedImage.image.raw;
+
+      // Set format based on mime type
+      // TODO(RSDK-11730): Remove format field and use mime type only
+      switch (namedImage.image.mimeType.type) {
+        case 'jpeg':
+          protoImage.format = Format.FORMAT_JPEG;
+          break;
+        case 'png':
+          protoImage.format = Format.FORMAT_PNG;
+          break;
+        case 'viamRgba':
+          protoImage.format = Format.FORMAT_RAW_RGBA;
+          break;
+        default:
+          protoImage.format = Format.FORMAT_UNSPECIFIED;
+      }
+
+      protoImage.mimeType = namedImage.image.mimeType.name;
+
+      response.images.add(protoImage);
+    }
+
+    // Convert native ResponseMetadata to protobuf type
+    if (result.metadata != null) {
+      response.responseMetadata = proto.ResponseMetadata()..capturedAt = Timestamp.fromDateTime(result.metadata!.capturedAt);
+    }
+
+    return response;
   }
 }

--- a/lib/src/media/image.dart
+++ b/lib/src/media/image.dart
@@ -3,6 +3,8 @@ import 'dart:typed_data';
 
 import 'package:image/image.dart' as img;
 
+import '../gen/component/camera/v1/camera.pbenum.dart';
+
 /// {@category Viam SDK}
 /// Mime types supported by Viam
 class MimeType {
@@ -53,6 +55,21 @@ class MimeType {
   /// Whether the provided String representation of a [MimeType] is supported
   static bool isSupported(String mimeType) {
     return _map.containsKey(mimeType);
+  }
+
+  /// Create a [MimeType] from a protobuf [Format] enum.
+  /// Returns [MimeType.unsupported] if the provided format is not supported
+  static MimeType fromFormat(Format format) {
+    switch (format) {
+      case Format.FORMAT_JPEG:
+        return MimeType.jpeg;
+      case Format.FORMAT_PNG:
+        return MimeType.png;
+      case Format.FORMAT_RAW_RGBA:
+        return MimeType.viamRgba;
+      default:
+        return MimeType.unsupported(format.toString());
+    }
   }
 
   @override


### PR DESCRIPTION
# Manual Tests

I wrote a demo web app Flutter client pinned to my local feature branch SDK. It calls a `image_file` camera on my local viam-server that has the new signature of `GetImages` implemented on the Go server side. I will be testing that filter source names indeed filters:

### Flutter client code:
```
    final machine = await RobotClient.atAddress(
      host,
      RobotClientOptions.withApiKey(apiKeyID, apiKey),
    );

    final imageFileCam = Camera.fromRobot(machine, "image-file-1") ;
    final resp = await imageFileCam.getImages();

    print("hi!");
    print(resp.metadata!.capturedAt);
    for (var img in resp.images) {
      print(img.image.mimeType);
    }
    print("bye!");
    await machine.close();
```

### Output:
```
hi!
2025-08-29 17:41:49.282364Z
image/jpeg
image/jpeg
FORMAT_RAW_DEPTH
bye!
```

### Changing the filter to only get back "preloaded":
```
...
    final resp = await imageFileCam.getImages(filterSourceNames: ["preloaded"]);
...
```

### Output:
```
hi!
2025-08-29 17:44:43.621434Z
image/jpeg
bye!
```