### PR TITLE
Handle eos marker for gRPC over WebRTC requests

### DIFF
--- a/lib/src/rpc/web_rtc/web_rtc_transport_stream.dart
+++ b/lib/src/rpc/web_rtc/web_rtc_transport_stream.dart
@@ -73,7 +73,7 @@ class WebRtcTransportStream extends GrpcTransportStream {
             ..stream = headersRequest.stream
             ..message = (grpc.RequestMessage()
               ..hasMessage = true
-              ..eos = false
+              ..eos = true
               ..packetMessage = (grpc.PacketMessage()
                 ..data = data
                 ..eom = true))
@@ -83,7 +83,7 @@ class WebRtcTransportStream extends GrpcTransportStream {
           ..stream = headersRequest.stream
           ..message = (grpc.RequestMessage()
             ..hasMessage = true
-            ..eos = false
+            ..eos = index == chunks.length - 1
             ..packetMessage = (grpc.PacketMessage()
               ..data = chunk
               ..eom = index == chunks.length - 1)));


### PR DESCRIPTION
### Description
#### Unary gRPC over our WebRTC transport worked, but server‑streaming RPCs stalled:

- Server never began emitting responses.
- Client timed out / cancelled.
- No server logs of the request payload in streaming case.


#### Problem: we never signaled client half‑close
- Sent headers frame (no embedded request bytes).
- Then sent single request message frame with `eom = true` (end of protobuf message) but `eos = false` (NOT end of client stream). 
- Even if the RPC endpoint only specifies a streaming response, the cardinality of the request also becomes a stream.
- Because eos stayed false, the server‑streaming handler (which waits for the client to finish sending before producing outbound frames) never transitioned to “ready to send,” so the response stream never started.

```
  rpc FetchStream(FetchStreamRequest) returns (stream FetchStreamResponse);
```

#### Unary appeared to work because:
- Unary handlers optimistically process the first (only) request message without requiring an explicit EOS.
- Some unary calls had the request bytes coalesced in the header, so the lack of explicit EOS was tolerated.

```
  rpc Fetch(FetchRequest) returns (FetchResponse);
```

## Testing
- Testing with custom videostore API
  - Unary endpoint ✅ 
  - Streaming  endpoint ✅ 
  
 ## Refs
 - [gRPC server streaming docs](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc): Details are pretty light in the documentation, so was hard to figure out that eos from the client is what I needed (only using server-side streaming).
