### PR TITLE
chore: bump claude CI workflows to v2.0.0

### DIFF
--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -21,8 +21,8 @@ jobs:
         github.event.workflow_run.conclusion == 'failure' &&
         startsWith(github.event.workflow_run.head_branch, 'claude/')
       )
-    # viamrobotics/claude-ci-workflows@v1.17.3
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@3ad96b0ccbb5ee0d7e2cde98653fae0c453e68bb
+    # viamrobotics/claude-ci-workflows@v2.0.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@aa76787c145ed43f8f7b9bae4d978da4f9850001
     with:
       run_id: ${{ github.event.workflow_run.id || inputs.run_id }}
       branch: ${{ github.event.workflow_run.head_branch || inputs.branch }}

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -50,8 +50,8 @@ on:
 
 jobs:
   call-jira:
-    # viamrobotics/claude-ci-workflows@v1.17.3
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@3ad96b0ccbb5ee0d7e2cde98653fae0c453e68bb
+    # viamrobotics/claude-ci-workflows@v2.0.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@aa76787c145ed43f8f7b9bae4d978da4f9850001
     with:
       ticket_id: ${{ github.event.client_payload.ticket_id || inputs.ticket_id }}
       summary: ${{ github.event.client_payload.summary || inputs.summary }}

--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -1,75 +1,12 @@
 name: Claude PR Assistant
 
 on:
-  workflow_run:
-    workflows: ["Test"]
-    types: [completed]
   issue_comment:
     types: [created]
   pull_request_review_comment:
     types: [created]
 
 jobs:
-  # --- Resolve PR data for auto-review ---
-  resolve-pr:
-    permissions:
-      contents: read
-    if: >-
-      github.repository_owner == 'viamrobotics' &&
-      github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'claude/')
-    runs-on: ubuntu-latest
-    outputs:
-      pr_found: ${{ steps.pr.outputs.found }}
-      pr_number: ${{ steps.pr.outputs.number }}
-      pr_title: ${{ steps.pr.outputs.title }}
-      branch: ${{ steps.pr.outputs.branch }}
-    steps:
-      - name: Find PR for branch
-        id: pr
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const branch = context.payload.workflow_run.head_branch;
-            const { data: pulls } = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              head: `${context.repo.owner}:${branch}`,
-              state: 'open'
-            });
-
-            if (pulls.length === 0) {
-              core.info('No open PR found for branch ' + branch);
-              core.setOutput('found', 'false');
-              return;
-            }
-
-            const pr = pulls[0];
-            core.setOutput('found', 'true');
-            core.setOutput('number', String(pr.number));
-            core.setOutput('title', pr.title);
-            core.setOutput('branch', branch);
-
-  # --- Auto-review after CI passes on claude/* branch ---
-  auto-review:
-    needs: resolve-pr
-    if: needs.resolve-pr.outputs.pr_found == 'true'
-    # viamrobotics/claude-ci-workflows@v1.17.3
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-auto-review.yml@3ad96b0ccbb5ee0d7e2cde98653fae0c453e68bb
-    with:
-      pr_number: ${{ needs.resolve-pr.outputs.pr_number }}
-      pr_title: ${{ needs.resolve-pr.outputs.pr_title }}
-      branch: ${{ needs.resolve-pr.outputs.branch }}
-      install_command: 'git clone https://github.com/flutter/flutter.git -b stable --depth 1 /opt/flutter && echo "/opt/flutter/bin" >> $GITHUB_PATH && /opt/flutter/bin/flutter pub get'
-      allowed_tools: 'Edit,Read,Write,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(make format*),Bash(make analyze*),Bash(flutter *),Bash(dart *),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git -C * diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr review*),Bash(gh pr comment*),Bash(gh pr diff*),Bash(gh pr view*),Bash(gh api repos/*/pulls/*/comments*)'
-      extra_review_instructions: |
-        - Ensure lib/src/gen/ was not modified.
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
-      SLACK_AI_WORKFLOW_ALERT_WEBHOOK_URL: ${{ secrets.SLACK_AI_WORKFLOW_ALERT_WEBHOOK_URL }}
-
   # --- On-demand review or fix via @claude mention ---
   on-demand:
     if: >-
@@ -78,8 +15,8 @@ jobs:
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
       )
-    # viamrobotics/claude-ci-workflows@v1.17.3
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@3ad96b0ccbb5ee0d7e2cde98653fae0c453e68bb
+    # viamrobotics/claude-ci-workflows@v2.0.0
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@aa76787c145ed43f8f7b9bae4d978da4f9850001
     with:
       install_command: 'git clone https://github.com/flutter/flutter.git -b stable --depth 1 /opt/flutter && echo "/opt/flutter/bin" >> $GITHUB_PATH && /opt/flutter/bin/flutter pub get'
       allowed_tools: 'Edit,Read,Write,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(make format*),Bash(make analyze*),Bash(make test*),Bash(make build_mocks*),Bash(flutter *),Bash(dart *),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git -C * diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr diff*),Bash(gh pr view*),Bash(gh api repos/*/pulls/*/comments*)'


### PR DESCRIPTION
## Summary
- Bump pinned SHA + version comment for `viamrobotics/claude-ci-workflows` to `v2.0.0` across all `claude-*.yml` callers.
- Drop the `auto-review` job and its `resolve-pr` workflow_run resolver from `claude-pr-assistant.yml` — `claude-auto-review.yml` was removed in v2.0.0 (see https://github.com/viamrobotics/claude-ci-workflows/releases/tag/v2.0.0).

## Test plan
- [ ] CI passes
- [ ] `@claude` mention on a PR still routes to the on-demand job

🤖 Generated with [Claude Code](https://claude.com/claude-code)