### PR TITLE
APP-16342: Add restartModule to RobotClient

### DIFF
--- a/lib/src/robot/client.dart
+++ b/lib/src/robot/client.dart
@@ -73,6 +73,17 @@ class RobotClient {
 
   RobotClient._();
 
+  /// Construct a [RobotClient] from an existing [rpb.RobotServiceClient].
+  ///
+  /// Most callers should use [atAddress] instead, which handles dialing,
+  /// session management, and resource discovery. This constructor is useful
+  /// when you have already obtained a [rpb.RobotServiceClient] (e.g. for
+  /// testing with a mock client). Methods that depend on the channel,
+  /// session, or resource manager will not work on instances created this way.
+  RobotClient.withClient(rpb.RobotServiceClient client) {
+    _client = client;
+  }
+
   /// Connect to a robot at the specified address with the provided options.
   ///
   /// ```
@@ -296,6 +307,21 @@ class RobotClient {
     final request = rpb.GetModelsFromModulesRequest();
     final response = await _client.getModelsFromModules(request);
     return response.models;
+  }
+
+  /// RestartModule restarts a module on the machine. Identify the module by either
+  /// [moduleId] (for registry modules) or [moduleName] (for local modules).
+  /// Exactly one of the two must be provided.
+  ///
+  /// ```
+  /// await machine.restartModule(moduleName: 'my-local-module');
+  /// ```
+  Future<void> restartModule({String? moduleId, String? moduleName}) async {
+    if ((moduleId == null) == (moduleName == null)) {
+      throw Exception('Exactly one of moduleId or moduleName must be provided');
+    }
+    final request = rpb.RestartModuleRequest(moduleId: moduleId, moduleName: moduleName);
+    await _client.restartModule(request);
   }
 
   /// GetMachineStatus returns status of the machine and its resources.

--- a/test/unit_test/robot/client_test.dart
+++ b/test/unit_test/robot/client_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:viam_sdk/src/gen/robot/v1/robot.pb.dart';
+import 'package:viam_sdk/viam_sdk.dart';
+
+import '../mocks/mock_response_future.dart';
+import '../mocks/service_clients_mocks.mocks.dart';
+
+void main() {
+  late MockRobotServiceClient serviceClient;
+  late RobotClient robotClient;
+
+  setUp(() {
+    serviceClient = MockRobotServiceClient();
+    robotClient = RobotClient.withClient(serviceClient);
+  });
+
+  group('RobotClient.restartModule', () {
+    test('sends moduleId for registry modules', () async {
+      when(serviceClient.restartModule(any)).thenAnswer((_) => MockResponseFuture.value(RestartModuleResponse()));
+
+      await robotClient.restartModule(moduleId: 'registry-id-123');
+
+      final captured = verify(serviceClient.restartModule(captureAny)).captured.single as RestartModuleRequest;
+      expect(captured.moduleId, equals('registry-id-123'));
+      expect(captured.hasModuleName(), isFalse);
+    });
+
+    test('sends moduleName for local modules', () async {
+      when(serviceClient.restartModule(any)).thenAnswer((_) => MockResponseFuture.value(RestartModuleResponse()));
+
+      await robotClient.restartModule(moduleName: 'my-local-module');
+
+      final captured = verify(serviceClient.restartModule(captureAny)).captured.single as RestartModuleRequest;
+      expect(captured.moduleName, equals('my-local-module'));
+      expect(captured.hasModuleId(), isFalse);
+    });
+
+    test('throws when neither moduleId nor moduleName is provided', () async {
+      expect(() => robotClient.restartModule(), throwsException);
+      verifyNever(serviceClient.restartModule(any));
+    });
+
+    test('throws when both moduleId and moduleName are provided', () async {
+      expect(() => robotClient.restartModule(moduleId: 'a', moduleName: 'b'), throwsException);
+      verifyNever(serviceClient.restartModule(any));
+    });
+  });
+}


### PR DESCRIPTION
This PR adds module restart wrappers into the Flutter SDK as well as tests for the robot client. I only added tests for restart module.

[https://viam.atlassian.net/browse/APP-16342](https://viam.atlassian.net/browse/APP-16342)