### PR TITLE
RSDK-13978 Add playStream to AudioOut

### DIFF
--- a/lib/src/components/audio_out/audio_out.dart
+++ b/lib/src/components/audio_out/audio_out.dart
@@ -14,6 +14,17 @@ abstract class AudioOut extends Resource {
   /// Play audio data on this audio output device
   Future<PlayResponse> play({required Uint8List audioData, required AudioInfo audioInfo, Map<String, dynamic>? extra});
 
+  /// Stream audio chunks to this audio output device for playback.
+  ///
+  /// The caller provides a [Stream] of raw audio bytes; each chunk must match
+  /// the codec and format described by [audioInfo]. Playback begins on the
+  /// device as chunks arrive, before the stream is exhausted.
+  Future<PlayStreamResponse> playStream({
+    required AudioInfo audioInfo,
+    required Stream<Uint8List> audioStream,
+    Map<String, dynamic>? extra,
+  });
+
   /// Get the audio properties of this audio output device
   Future<GetPropertiesResponse> getProperties({Map<String, dynamic>? extra});
 

--- a/lib/src/components/audio_out/client.dart
+++ b/lib/src/components/audio_out/client.dart
@@ -33,6 +33,28 @@ class AudioOutClient extends AudioOut implements ResourceRPCClient {
   }
 
   @override
+  Future<PlayStreamResponse> playStream({
+    required AudioInfo audioInfo,
+    required Stream<Uint8List> audioStream,
+    Map<String, dynamic>? extra,
+  }) async {
+    final init = PlayStreamRequest()
+      ..init = (PlayStreamInit()
+        ..name = name
+        ..audioInfo = audioInfo
+        ..extra = extra?.toStruct() ?? Struct());
+
+    Stream<PlayStreamRequest> requests() async* {
+      yield init;
+      await for (final chunk in audioStream) {
+        yield PlayStreamRequest()..audioChunk = (PlayStreamChunk()..audioData = chunk);
+      }
+    }
+
+    return await client.playStream(requests());
+  }
+
+  @override
   Future<GetPropertiesResponse> getProperties({Map<String, dynamic>? extra}) async {
     final request = GetPropertiesRequest()
       ..name = name

--- a/lib/src/components/audio_out/service.dart
+++ b/lib/src/components/audio_out/service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:grpc/grpc.dart';
@@ -30,6 +31,36 @@ class AudioOutService extends AudioOutServiceBase {
       audioData: audioData is Uint8List ? audioData : Uint8List.fromList(audioData),
       audioInfo: request.audioInfo,
       extra: request.hasExtra() ? request.extra.toMap() : null,
+    );
+  }
+
+  @override
+  Future<PlayStreamResponse> playStream(ServiceCall call, Stream<PlayStreamRequest> request) async {
+    final iter = StreamIterator(request);
+    if (!await iter.moveNext()) {
+      throw GrpcError.invalidArgument('PlayStream: stream closed before init message');
+    }
+    final first = iter.current;
+    if (!first.hasInit()) {
+      throw GrpcError.invalidArgument('PlayStream: first message must be PlayStreamInit');
+    }
+    final init = first.init;
+    final audioOut = _fromManager(init.name);
+
+    Stream<Uint8List> chunks() async* {
+      while (await iter.moveNext()) {
+        final msg = iter.current;
+        if (msg.hasAudioChunk()) {
+          final bytes = msg.audioChunk.audioData;
+          yield bytes is Uint8List ? bytes : Uint8List.fromList(bytes);
+        }
+      }
+    }
+
+    return audioOut.playStream(
+      audioInfo: init.audioInfo,
+      audioStream: chunks(),
+      extra: init.hasExtra() ? init.extra.toMap() : null,
     );
   }
 

--- a/lib/src/components/audio_out/service.dart
+++ b/lib/src/components/audio_out/service.dart
@@ -78,11 +78,6 @@ class AudioOutService extends AudioOutServiceBase {
   }
 
   @override
-  Future<PlayStreamResponse> playStream(ServiceCall call, Stream<PlayStreamRequest> request) {
-    throw UnimplementedError();
-  }
-
-  @override
   Future<GetGeometriesResponse> getGeometries(ServiceCall call, GetGeometriesRequest request) {
     throw UnimplementedError();
   }

--- a/test/unit_test/components/audio_out_test.dart
+++ b/test/unit_test/components/audio_out_test.dart
@@ -15,6 +15,9 @@ class FakeAudioOut extends AudioOut {
   Map<String, dynamic>? extra;
   Map<String, dynamic>? propertiesExtra;
   Map<String, dynamic> statusResult = {'status': 'ok'};
+  AudioInfo? streamedAudioInfo;
+  List<Uint8List> streamedChunks = [];
+  Map<String, dynamic>? streamedExtra;
 
   @override
   String name;
@@ -37,6 +40,21 @@ class FakeAudioOut extends AudioOut {
     this.audioInfo = audioInfo;
     this.extra = extra;
     return PlayResponse();
+  }
+
+  @override
+  Future<PlayStreamResponse> playStream({
+    required AudioInfo audioInfo,
+    required Stream<Uint8List> audioStream,
+    Map<String, dynamic>? extra,
+  }) async {
+    streamedAudioInfo = audioInfo;
+    streamedExtra = extra;
+    streamedChunks = [];
+    await for (final chunk in audioStream) {
+      streamedChunks.add(chunk);
+    }
+    return PlayStreamResponse();
   }
 
   @override
@@ -80,6 +98,36 @@ void main() {
       expect(audioOut.audioData, audioData);
       expect(audioOut.audioInfo, audioInfo);
       expect(audioOut.extra, null);
+    });
+
+    test('playStream drains chunks', () async {
+      final audioInfo = AudioInfo()
+        ..codec = AudioCodec.pcm16
+        ..sampleRateHz = 22050
+        ..numChannels = 1;
+      final chunks = [
+        Uint8List.fromList([1, 2, 3]),
+        Uint8List.fromList([4, 5, 6]),
+        Uint8List.fromList([7, 8, 9]),
+      ];
+
+      final result = await audioOut.playStream(
+        audioInfo: audioInfo,
+        audioStream: Stream.fromIterable(chunks),
+      );
+
+      expect(result, isA<PlayStreamResponse>());
+      expect(audioOut.streamedAudioInfo, audioInfo);
+      expect(audioOut.streamedChunks, chunks);
+    });
+
+    test('playStream with empty stream', () async {
+      final audioInfo = AudioInfo()..codec = AudioCodec.pcm16;
+
+      await audioOut.playStream(audioInfo: audioInfo, audioStream: const Stream.empty());
+
+      expect(audioOut.streamedAudioInfo, audioInfo);
+      expect(audioOut.streamedChunks, isEmpty);
     });
 
     test('getProperties', () async {
@@ -159,6 +207,36 @@ void main() {
         expect(audioOut.audioInfo?.sampleRateHz, 48000);
         expect(audioOut.extra, extra);
       });
+      test('playStream', () async {
+        final audioInfo = AudioInfo()
+          ..codec = AudioCodec.pcm16
+          ..numChannels = 1
+          ..sampleRateHz = 22050;
+        final chunks = [
+          Uint8List.fromList([10, 11, 12]),
+          Uint8List.fromList([13, 14, 15]),
+        ];
+        final extra = {'session': 'abc'};
+
+        final client = AudioOutServiceClient(channel);
+        final requests = Stream<PlayStreamRequest>.fromIterable([
+          PlayStreamRequest()
+            ..init = (PlayStreamInit()
+              ..name = name
+              ..audioInfo = audioInfo
+              ..extra = extra.toStruct()),
+          for (final chunk in chunks) PlayStreamRequest()..audioChunk = (PlayStreamChunk()..audioData = chunk),
+        ]);
+
+        final result = await client.playStream(requests);
+
+        expect(result, isA<PlayStreamResponse>());
+        expect(audioOut.streamedAudioInfo?.codec, AudioCodec.pcm16);
+        expect(audioOut.streamedAudioInfo?.sampleRateHz, 22050);
+        expect(audioOut.streamedChunks, chunks);
+        expect(audioOut.streamedExtra, extra);
+      });
+
       test('getProperties', () async {
         final client = AudioOutServiceClient(channel);
         final result = await client.getProperties(GetPropertiesRequest()..name = name);
@@ -213,6 +291,32 @@ void main() {
         expect(audioOut.audioInfo?.numChannels, 2);
         expect(audioOut.audioInfo?.sampleRateHz, 22050);
         expect(audioOut.extra, extra);
+      });
+
+      test('playStream', () async {
+        final audioInfo = AudioInfo()
+          ..codec = AudioCodec.opus
+          ..numChannels = 2
+          ..sampleRateHz = 48000;
+        final chunks = [
+          Uint8List.fromList([100, 101]),
+          Uint8List.fromList([102, 103]),
+        ];
+        final extra = {'k': 'v'};
+
+        final client = AudioOutClient(name, channel);
+        final result = await client.playStream(
+          audioInfo: audioInfo,
+          audioStream: Stream.fromIterable(chunks),
+          extra: extra,
+        );
+
+        expect(result, isA<PlayStreamResponse>());
+        expect(audioOut.streamedAudioInfo?.codec, AudioCodec.opus);
+        expect(audioOut.streamedAudioInfo?.numChannels, 2);
+        expect(audioOut.streamedAudioInfo?.sampleRateHz, 48000);
+        expect(audioOut.streamedChunks, chunks);
+        expect(audioOut.streamedExtra, extra);
       });
 
       test('getProperties', () async {


### PR DESCRIPTION
Wraps the new PlayStream client-streaming RPC on the audio_out service. Caller provides an `AudioInfo` plus a `Stream<Uint8List>` of audio chunks; the SDK sends an init message first then forwards each chunk as a `PlayStreamChunk`.

Adds tests against `FakeAudioOut`, the raw service stub, and `AudioOutClient`.

Needs protos merged first 