### PR TITLE
RSDK-11037 Add geometries to every component

### DIFF
--- a/lib/src/components/audio_in/audio_in.dart
+++ b/lib/src/components/audio_in/audio_in.dart
@@ -22,6 +22,13 @@ abstract class AudioIn extends Resource {
   /// Get the audio properties of this audio in device
   Future<GetPropertiesResponse> getProperties({Map<String, dynamic>? extra});
 
+  /// Get all geometries associated with the [AudioIn]
+  ///
+  /// ```
+  /// final geometries = await myAudioIn.getGeometries();
+  /// ```
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra});
+
   /// Get the [ResourceName] for this [AudioIn] with the given [name]
   static ResourceName getResourceName(String name) {
     return AudioIn.subtype.getResourceName(name);

--- a/lib/src/components/audio_in/client.dart
+++ b/lib/src/components/audio_in/client.dart
@@ -23,6 +23,15 @@ class AudioInClient extends AudioIn implements ResourceRPCClient {
   AudioInClient(this.name, this.channel);
 
   @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    final request = GetGeometriesRequest()
+      ..name = name
+      ..extra = extra?.toStruct() ?? Struct();
+    final response = await client.getGeometries(request);
+    return response.geometries;
+  }
+
+  @override
   Stream<GetAudioResponse> getAudio({
     required String codec,
     double? durationSeconds,

--- a/lib/src/components/audio_in/service.dart
+++ b/lib/src/components/audio_in/service.dart
@@ -61,7 +61,9 @@ class AudioInService extends AudioInServiceBase {
   }
 
   @override
-  Future<GetGeometriesResponse> getGeometries(ServiceCall call, GetGeometriesRequest request) {
-    throw UnimplementedError();
+  Future<GetGeometriesResponse> getGeometries(ServiceCall call, GetGeometriesRequest request) async {
+    final audioIn = _fromManager(request.name);
+    final geometries = await audioIn.getGeometries(extra: request.extra.toMap());
+    return GetGeometriesResponse()..geometries.addAll(geometries);
   }
 }

--- a/lib/src/components/audio_out/audio_out.dart
+++ b/lib/src/components/audio_out/audio_out.dart
@@ -28,6 +28,13 @@ abstract class AudioOut extends Resource {
   /// Get the audio properties of this audio output device
   Future<GetPropertiesResponse> getProperties({Map<String, dynamic>? extra});
 
+  /// Get all geometries associated with the [AudioOut]
+  ///
+  /// ```
+  /// final geometries = await myAudioOut.getGeometries();
+  /// ```
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra});
+
   /// Get the [ResourceName] for this [AudioOut] with the given [name]
   static ResourceName getResourceName(String name) {
     return AudioOut.subtype.getResourceName(name);

--- a/lib/src/components/audio_out/client.dart
+++ b/lib/src/components/audio_out/client.dart
@@ -23,6 +23,15 @@ class AudioOutClient extends AudioOut implements ResourceRPCClient {
   AudioOutClient(this.name, this.channel);
 
   @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    final request = GetGeometriesRequest()
+      ..name = name
+      ..extra = extra?.toStruct() ?? Struct();
+    final response = await client.getGeometries(request);
+    return response.geometries;
+  }
+
+  @override
   Future<PlayResponse> play({required Uint8List audioData, required AudioInfo audioInfo, Map<String, dynamic>? extra}) async {
     final request = PlayRequest()
       ..name = name

--- a/lib/src/components/audio_out/service.dart
+++ b/lib/src/components/audio_out/service.dart
@@ -78,8 +78,10 @@ class AudioOutService extends AudioOutServiceBase {
   }
 
   @override
-  Future<GetGeometriesResponse> getGeometries(ServiceCall call, GetGeometriesRequest request) {
-    throw UnimplementedError();
+  Future<GetGeometriesResponse> getGeometries(ServiceCall call, GetGeometriesRequest request) async {
+    final audioOut = _fromManager(request.name);
+    final geometries = await audioOut.getGeometries(extra: request.extra.toMap());
+    return GetGeometriesResponse()..geometries.addAll(geometries);
   }
 
   @override

--- a/lib/src/components/base/base.dart
+++ b/lib/src/components/base/base.dart
@@ -97,6 +97,15 @@ abstract class Base extends Resource {
   /// For more information, see [Base component](https://docs.viam.com/dev/reference/apis/components/base/#ismoving).
   Future<bool> isMoving();
 
+  /// Get all geometries associated with the [Base]
+  ///
+  /// ```
+  /// final geometries = await myBase.getGeometries();
+  /// ```
+  ///
+  /// For more information, see [Base component](https://docs.viam.com/dev/reference/apis/components/base/#getgeometries).
+  Future<List<common_pb.Geometry>> getGeometries({Map<String, dynamic>? extra});
+
   /// Get the [common_pb.ResourceName] for this [Base] with the given [name]
   ///
   /// For more information, see [Base component](https://docs.viam.com/dev/reference/apis/components/base/#getresourcename).

--- a/lib/src/components/base/client.dart
+++ b/lib/src/components/base/client.dart
@@ -23,6 +23,15 @@ class BaseClient extends Base with RPCDebugLoggerMixin implements ResourceRPCCli
   BaseClient(this.name, this.channel);
 
   @override
+  Future<List<common_pb.Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    final request = common_pb.GetGeometriesRequest()
+      ..name = name
+      ..extra = extra?.toStruct() ?? Struct();
+    final response = await client.getGeometries(request, options: callOptions);
+    return response.geometries;
+  }
+
+  @override
   Future<bool> isMoving() async {
     final request = IsMovingRequest()..name = name;
     final response = await client.isMoving(request, options: callOptions);

--- a/lib/src/components/base/service.dart
+++ b/lib/src/components/base/service.dart
@@ -71,9 +71,10 @@ class BaseService extends BaseServiceBase {
   }
 
   @override
-  Future<common_pb.GetGeometriesResponse> getGeometries(ServiceCall call, common_pb.GetGeometriesRequest request) {
-    // TODO: implement getGeometries
-    throw UnimplementedError();
+  Future<common_pb.GetGeometriesResponse> getGeometries(ServiceCall call, common_pb.GetGeometriesRequest request) async {
+    final base = _fromManager(request.name);
+    final geometries = await base.getGeometries(extra: request.extra.toMap());
+    return common_pb.GetGeometriesResponse()..geometries.addAll(geometries);
   }
 
   @override

--- a/lib/src/components/board/board.dart
+++ b/lib/src/components/board/board.dart
@@ -145,6 +145,15 @@ abstract class Board extends Resource {
   /// For more information, see [Board component](https://docs.viam.com/dev/reference/apis/components/board/#writeanalog).
   Future<void> writeAnalog(String pin, int value, {Map<String, dynamic>? extra});
 
+  /// Get all geometries associated with the [Board]
+  ///
+  /// ```
+  /// final geometries = await myBoard.getGeometries();
+  /// ```
+  ///
+  /// For more information, see [Board component](https://docs.viam.com/dev/reference/apis/components/board/#getgeometries).
+  Future<List<common.Geometry>> getGeometries({Map<String, dynamic>? extra});
+
   /// Get the [ResourceName] for this [Board] with the given [name]
   ///
   /// ```

--- a/lib/src/components/board/client.dart
+++ b/lib/src/components/board/client.dart
@@ -27,6 +27,15 @@ class BoardClient extends Board with RPCDebugLoggerMixin implements ResourceRPCC
   BoardClient(this.name, this.channel);
 
   @override
+  Future<List<common.Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    final request = common.GetGeometriesRequest()
+      ..name = name
+      ..extra = extra?.toStruct() ?? Struct();
+    final response = await client.getGeometries(request, options: callOptions);
+    return response.geometries;
+  }
+
+  @override
   Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) async {
     final request = common.DoCommandRequest()
       ..name = name

--- a/lib/src/components/board/service.dart
+++ b/lib/src/components/board/service.dart
@@ -95,9 +95,10 @@ class BoardService extends BoardServiceBase {
   }
 
   @override
-  Future<common.GetGeometriesResponse> getGeometries(ServiceCall call, common.GetGeometriesRequest request) {
-    // TODO: implement getGeometries
-    throw UnimplementedError();
+  Future<common.GetGeometriesResponse> getGeometries(ServiceCall call, common.GetGeometriesRequest request) async {
+    final board = _fromManager(request.name);
+    final geometries = await board.getGeometries(extra: request.extra.toMap());
+    return common.GetGeometriesResponse()..geometries.addAll(geometries);
   }
 
   @override

--- a/lib/src/components/camera/camera.dart
+++ b/lib/src/components/camera/camera.dart
@@ -87,6 +87,15 @@ abstract class Camera extends Resource {
   /// For more information, see [Camera component](https://docs.viam.com/dev/reference/apis/components/camera/#getimages).
   Future<GetImagesResult> getImages({List<String>? filterSourceNames, Map<String, dynamic>? extra});
 
+  /// Get all geometries associated with the [Camera]
+  ///
+  /// ```
+  /// final geometries = await myCamera.getGeometries();
+  /// ```
+  ///
+  /// For more information, see [Camera component](https://docs.viam.com/dev/reference/apis/components/camera/#getgeometries).
+  Future<List<common_pb.Geometry>> getGeometries({Map<String, dynamic>? extra});
+
   /// Get the [common_pb.ResourceName] for this [Camera] with the given [name]
   ///
   /// ```

--- a/lib/src/components/camera/client.dart
+++ b/lib/src/components/camera/client.dart
@@ -23,6 +23,15 @@ class CameraClient extends Camera with RPCDebugLoggerMixin implements ResourceRP
   CameraClient(this.name, this.channel);
 
   @override
+  Future<List<proto.Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    final request = proto.GetGeometriesRequest()
+      ..name = name
+      ..extra = extra?.toStruct() ?? Struct();
+    final response = await client.getGeometries(request, options: callOptions);
+    return response.geometries;
+  }
+
+  @override
   Future<ViamImage> pointCloud({Map<String, dynamic>? extra}) async {
     final request = GetPointCloudRequest()
       ..name = name

--- a/lib/src/components/camera/service.dart
+++ b/lib/src/components/camera/service.dart
@@ -46,9 +46,10 @@ class CameraService extends CameraServiceBase {
   }
 
   @override
-  Future<proto.GetGeometriesResponse> getGeometries(ServiceCall call, proto.GetGeometriesRequest request) {
-    // TODO: implement getGeometries
-    throw UnimplementedError();
+  Future<proto.GetGeometriesResponse> getGeometries(ServiceCall call, proto.GetGeometriesRequest request) async {
+    final camera = _fromManager(request.name);
+    final geometries = await camera.getGeometries(extra: request.extra.toMap());
+    return proto.GetGeometriesResponse()..geometries.addAll(geometries);
   }
 
   @override

--- a/lib/src/components/generic/client.dart
+++ b/lib/src/components/generic/client.dart
@@ -2,6 +2,7 @@ import 'package:grpc/grpc_connection_interface.dart';
 
 import '../../gen/common/v1/common.pb.dart';
 import '../../gen/component/generic/v1/generic.pbgrpc.dart';
+import '../../gen/google/protobuf/struct.pb.dart';
 import '../../resource/base.dart';
 import '../../utils.dart';
 import 'generic.dart';
@@ -19,6 +20,15 @@ class GenericClient extends Generic with RPCDebugLoggerMixin implements Resource
   GenericServiceClient get client => GenericServiceClient(channel);
 
   GenericClient(this.name, this.channel);
+
+  @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    final request = GetGeometriesRequest()
+      ..name = name
+      ..extra = extra?.toStruct() ?? Struct();
+    final response = await client.getGeometries(request, options: callOptions);
+    return response.geometries;
+  }
 
   @override
   Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) async {

--- a/lib/src/components/generic/generic.dart
+++ b/lib/src/components/generic/generic.dart
@@ -9,6 +9,15 @@ import '../../robot/client.dart';
 abstract class Generic extends Resource {
   static const Subtype subtype = Subtype(resourceNamespaceRDK, resourceTypeComponent, 'generic');
 
+  /// Get all geometries associated with the [Generic]
+  ///
+  /// ```
+  /// final geometries = await myGeneric.getGeometries();
+  /// ```
+  ///
+  /// For more information, see [Generic component](https://docs.viam.com/dev/reference/apis/components/generic/#getgeometries).
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra});
+
   /// Get the [ResourceName] for this [Generic] with the given [name]
   ///
   /// ```

--- a/lib/src/components/generic/service.dart
+++ b/lib/src/components/generic/service.dart
@@ -29,9 +29,10 @@ class GenericService extends GenericServiceBase {
   }
 
   @override
-  Future<GetGeometriesResponse> getGeometries(ServiceCall call, GetGeometriesRequest request) {
-    // TODO: implement getGeometries
-    throw UnimplementedError();
+  Future<GetGeometriesResponse> getGeometries(ServiceCall call, GetGeometriesRequest request) async {
+    final generic = _fromManager(request.name);
+    final geometries = await generic.getGeometries(extra: request.extra.toMap());
+    return GetGeometriesResponse()..geometries.addAll(geometries);
   }
 
   @override

--- a/lib/src/components/gripper/client.dart
+++ b/lib/src/components/gripper/client.dart
@@ -22,6 +22,15 @@ class GripperClient extends Gripper with RPCDebugLoggerMixin implements Resource
   GripperClient(this.name, this.channel);
 
   @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    final request = GetGeometriesRequest()
+      ..name = name
+      ..extra = extra?.toStruct() ?? Struct();
+    final response = await client.getGeometries(request, options: callOptions);
+    return response.geometries;
+  }
+
+  @override
   Future<void> grab({Map<String, dynamic>? extra}) async {
     final request = GrabRequest()
       ..name = name

--- a/lib/src/components/gripper/gripper.dart
+++ b/lib/src/components/gripper/gripper.dart
@@ -79,6 +79,15 @@ abstract class Gripper extends Resource {
   /// For more information, see [Gripper component](https://docs.viam.com/dev/reference/apis/components/gripper/#getkinematics).
   Future<Kinematics> getKinematics({Map<String, dynamic>? extra});
 
+  /// Get all geometries associated with the [Gripper]
+  ///
+  /// ```
+  /// final geometries = await myGripper.getGeometries();
+  /// ```
+  ///
+  /// For more information, see [Gripper component](https://docs.viam.com/dev/reference/apis/components/gripper/#getgeometries).
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra});
+
   /// Get the [ResourceName] for the [Gripper] with the given [name]
   ///
   /// ```

--- a/lib/src/components/gripper/service.dart
+++ b/lib/src/components/gripper/service.dart
@@ -29,9 +29,10 @@ class GripperService extends GripperServiceBase {
   }
 
   @override
-  Future<GetGeometriesResponse> getGeometries(ServiceCall call, GetGeometriesRequest request) {
-    // TODO: implement getGeometries
-    throw UnimplementedError();
+  Future<GetGeometriesResponse> getGeometries(ServiceCall call, GetGeometriesRequest request) async {
+    final gripper = _fromManager(request.name);
+    final geometries = await gripper.getGeometries(extra: request.extra.toMap());
+    return GetGeometriesResponse()..geometries.addAll(geometries);
   }
 
   @override

--- a/lib/src/components/input_controller/client.dart
+++ b/lib/src/components/input_controller/client.dart
@@ -58,11 +58,13 @@ class InputControllerClient extends InputController with RPCDebugLoggerMixin imp
     await client.triggerEvent(request, options: callOptions);
   }
 
-  Future<common_pb.GetGeometriesResponse> getGeometries({Map<String, dynamic>? extra}) async {
+  @override
+  Future<List<common_pb.Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
     final request = common_pb.GetGeometriesRequest()
       ..name = name
       ..extra = extra?.toStruct() ?? Struct();
-    return await client.getGeometries(request, options: callOptions);
+    final response = await client.getGeometries(request, options: callOptions);
+    return response.geometries;
   }
 
   @override

--- a/lib/src/components/input_controller/input_controller.dart
+++ b/lib/src/components/input_controller/input_controller.dart
@@ -66,6 +66,15 @@ abstract class InputController extends Resource {
     Map<String, dynamic>? extra,
   });
 
+  /// Get all geometries associated with the [InputController]
+  ///
+  /// ```
+  /// final geometries = await myInputController.getGeometries();
+  /// ```
+  ///
+  /// For more information, see [InputController component](https://docs.viam.com/dev/reference/apis/components/input-controller/#getgeometries).
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra});
+
   /// Get the [ResourceName] for this [InputController] with the given [name]
   ///
   /// ```

--- a/lib/src/components/input_controller/service.dart
+++ b/lib/src/components/input_controller/service.dart
@@ -45,9 +45,10 @@ class InputControllerService extends InputControllerServiceBase {
   }
 
   @override
-  Future<common_pb.GetGeometriesResponse> getGeometries(ServiceCall call, common_pb.GetGeometriesRequest request) {
-    // TODO: implement getGeometries
-    throw UnimplementedError();
+  Future<common_pb.GetGeometriesResponse> getGeometries(ServiceCall call, common_pb.GetGeometriesRequest request) async {
+    final inputController = _fromManager(request.name);
+    final geometries = await inputController.getGeometries(extra: request.extra.toMap());
+    return common_pb.GetGeometriesResponse()..geometries.addAll(geometries);
   }
 
   @override

--- a/lib/src/components/motor/client.dart
+++ b/lib/src/components/motor/client.dart
@@ -110,6 +110,15 @@ class MotorClient extends Motor with RPCDebugLoggerMixin implements ResourceRPCC
   }
 
   @override
+  Future<List<common_pb.Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    final request = common_pb.GetGeometriesRequest()
+      ..name = name
+      ..extra = extra?.toStruct() ?? Struct();
+    final response = await client.getGeometries(request, options: callOptions);
+    return response.geometries;
+  }
+
+  @override
   Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) async {
     final request = common_pb.DoCommandRequest()
       ..name = name

--- a/lib/src/components/motor/motor.dart
+++ b/lib/src/components/motor/motor.dart
@@ -141,6 +141,15 @@ abstract class Motor extends Resource {
   /// For more information, see [Motor component](https://docs.viam.com/dev/reference/apis/components/motor/#ismoving).
   Future<bool> isMoving({Map<String, dynamic>? extra});
 
+  /// Get all geometries associated with the [Motor]
+  ///
+  /// ```
+  /// final geometries = await myMotor.getGeometries();
+  /// ```
+  ///
+  /// For more information, see [Motor component](https://docs.viam.com/dev/reference/apis/components/motor/#getgeometries).
+  Future<List<common_pb.Geometry>> getGeometries({Map<String, dynamic>? extra});
+
   /// Get the [common_pb.ResourceName] for this [Motor] with the given [name].
   ///
   /// ```

--- a/lib/src/components/motor/service.dart
+++ b/lib/src/components/motor/service.dart
@@ -101,9 +101,10 @@ class MotorService extends MotorServiceBase {
   }
 
   @override
-  Future<common_pb.GetGeometriesResponse> getGeometries(ServiceCall call, common_pb.GetGeometriesRequest request) {
-    // TODO: implement getGeometries
-    throw UnimplementedError();
+  Future<common_pb.GetGeometriesResponse> getGeometries(ServiceCall call, common_pb.GetGeometriesRequest request) async {
+    final motor = _fromManager(request.name);
+    final geometries = await motor.getGeometries(extra: request.extra.toMap());
+    return common_pb.GetGeometriesResponse()..geometries.addAll(geometries);
   }
 
   @override

--- a/lib/src/components/movement_sensor/client.dart
+++ b/lib/src/components/movement_sensor/client.dart
@@ -22,6 +22,15 @@ class MovementSensorClient extends MovementSensor with RPCDebugLoggerMixin imple
   MovementSensorClient(this.name, this.channel);
 
   @override
+  Future<List<common_pb.Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    final request = common_pb.GetGeometriesRequest()
+      ..name = name
+      ..extra = extra?.toStruct() ?? Struct();
+    final response = await client.getGeometries(request, options: callOptions);
+    return response.geometries;
+  }
+
+  @override
   Future<Map<String, dynamic>> readings({Map<String, dynamic>? extra}) async {
     final request = common_pb.GetReadingsRequest()
       ..name = name

--- a/lib/src/components/movement_sensor/movement_sensor.dart
+++ b/lib/src/components/movement_sensor/movement_sensor.dart
@@ -113,6 +113,15 @@ abstract class MovementSensor extends Resource {
   /// For more information, see [Movement Sensor component](https://docs.viam.com/dev/reference/apis/components/movement-sensor/#getaccuracy).
   Future<Accuracy> accuracy({Map<String, dynamic>? extra});
 
+  /// Get all geometries associated with the [MovementSensor]
+  ///
+  /// ```
+  /// final geometries = await myMovementSensor.getGeometries();
+  /// ```
+  ///
+  /// For more information, see [Movement Sensor component](https://docs.viam.com/dev/reference/apis/components/movement-sensor/#getgeometries).
+  Future<List<common_pb.Geometry>> getGeometries({Map<String, dynamic>? extra});
+
   /// Get the [common_pb.ResourceName] for this [MovementSensor] with the given [name]
   ///
   /// ```

--- a/lib/src/components/movement_sensor/service.dart
+++ b/lib/src/components/movement_sensor/service.dart
@@ -99,9 +99,10 @@ class MovementSensorService extends MovementSensorServiceBase {
   }
 
   @override
-  Future<common_pb.GetGeometriesResponse> getGeometries(ServiceCall call, common_pb.GetGeometriesRequest request) {
-    // TODO: implement getGeometries
-    throw UnimplementedError();
+  Future<common_pb.GetGeometriesResponse> getGeometries(ServiceCall call, common_pb.GetGeometriesRequest request) async {
+    final movementSensor = _fromManager(request.name);
+    final geometries = await movementSensor.getGeometries(extra: request.extra.toMap());
+    return common_pb.GetGeometriesResponse()..geometries.addAll(geometries);
   }
 
   @override

--- a/lib/src/components/sensor/client.dart
+++ b/lib/src/components/sensor/client.dart
@@ -22,6 +22,15 @@ class SensorClient extends Sensor with RPCDebugLoggerMixin implements ResourceRP
   SensorClient(this.name, this.channel);
 
   @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    final request = GetGeometriesRequest()
+      ..name = name
+      ..extra = extra?.toStruct() ?? Struct();
+    final response = await client.getGeometries(request, options: callOptions);
+    return response.geometries;
+  }
+
+  @override
   Future<Map<String, dynamic>> readings({Map<String, dynamic>? extra}) async {
     final request = GetReadingsRequest()
       ..name = name

--- a/lib/src/components/sensor/sensor.dart
+++ b/lib/src/components/sensor/sensor.dart
@@ -18,6 +18,15 @@ abstract class Sensor extends Resource {
   /// For more information, see [Sensor component](https://docs.viam.com/dev/reference/apis/components/sensor/#getreadings).
   Future<Map<String, dynamic>> readings({Map<String, dynamic>? extra});
 
+  /// Get all geometries associated with the [Sensor]
+  ///
+  /// ```
+  /// final geometries = await mySensor.getGeometries();
+  /// ```
+  ///
+  /// For more information, see [Sensor component](https://docs.viam.com/dev/reference/apis/components/sensor/#getgeometries).
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra});
+
   /// Get the [ResourceName] for this [Sensor] with the given [name].
   ///
   /// ```

--- a/lib/src/components/sensor/service.dart
+++ b/lib/src/components/sensor/service.dart
@@ -36,9 +36,10 @@ class SensorService extends SensorServiceBase {
   }
 
   @override
-  Future<GetGeometriesResponse> getGeometries(ServiceCall call, GetGeometriesRequest request) {
-    // TODO: implement getGeometries
-    throw UnimplementedError();
+  Future<GetGeometriesResponse> getGeometries(ServiceCall call, GetGeometriesRequest request) async {
+    final sensor = _fromManager(request.name);
+    final geometries = await sensor.getGeometries(extra: request.extra.toMap());
+    return GetGeometriesResponse()..geometries.addAll(geometries);
   }
 
   @override

--- a/lib/src/components/servo/client.dart
+++ b/lib/src/components/servo/client.dart
@@ -22,6 +22,15 @@ class ServoClient extends Servo with RPCDebugLoggerMixin implements ResourceRPCC
   ServoClient(this.name, this.channel);
 
   @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    final request = GetGeometriesRequest()
+      ..name = name
+      ..extra = extra?.toStruct() ?? Struct();
+    final response = await client.getGeometries(request, options: callOptions);
+    return response.geometries;
+  }
+
+  @override
   Future<void> move(int angle, {Map<String, dynamic>? extra}) async {
     final request = MoveRequest()
       ..name = name

--- a/lib/src/components/servo/service.dart
+++ b/lib/src/components/servo/service.dart
@@ -57,9 +57,10 @@ class ServoService extends ServoServiceBase {
   }
 
   @override
-  Future<GetGeometriesResponse> getGeometries(ServiceCall call, GetGeometriesRequest request) {
-    // TODO: implement getGeometries
-    throw UnimplementedError();
+  Future<GetGeometriesResponse> getGeometries(ServiceCall call, GetGeometriesRequest request) async {
+    final servo = _fromManager(request.name);
+    final geometries = await servo.getGeometries(extra: request.extra.toMap());
+    return GetGeometriesResponse()..geometries.addAll(geometries);
   }
 
   @override

--- a/lib/src/components/servo/servo.dart
+++ b/lib/src/components/servo/servo.dart
@@ -45,6 +45,15 @@ abstract class Servo extends Resource {
   /// For more information, see [Servo component](https://docs.viam.com/dev/reference/apis/components/servo/#ismoving).
   Future<bool> isMoving();
 
+  /// Get all geometries associated with the [Servo]
+  ///
+  /// ```
+  /// final geometries = await myServo.getGeometries();
+  /// ```
+  ///
+  /// For more information, see [Servo component](https://docs.viam.com/dev/reference/apis/components/servo/#getgeometries).
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra});
+
   /// Get the [ResourceName] for this [Servo] with the given [name].
   ///
   /// ```

--- a/test/unit_test/components/audio_in_test.dart
+++ b/test/unit_test/components/audio_in_test.dart
@@ -67,6 +67,14 @@ class FakeAudioIn extends AudioIn {
     propertiesExtra = extra;
     return GetPropertiesResponse();
   }
+
+  List<Geometry> geometries = [Geometry()..label = 'test'];
+
+  @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    this.extra = extra;
+    return geometries;
+  }
 }
 
 void main() {
@@ -132,6 +140,11 @@ void main() {
     test('getStatus', () async {
       final result = await audioIn.getStatus();
       expect(result, audioIn.statusResult);
+    });
+
+    test('getGeometries', () async {
+      final result = await audioIn.getGeometries();
+      expect(result, audioIn.geometries);
     });
   });
 
@@ -237,6 +250,12 @@ void main() {
         final response = await client.getStatus(GetStatusRequest()..name = name);
         expect(response.result.toMap(), audioIn.statusResult);
       });
+
+      test('getGeometries', () async {
+        final client = AudioInServiceClient(channel);
+        final response = await client.getGeometries(GetGeometriesRequest()..name = name);
+        expect(response.geometries, audioIn.geometries);
+      });
     });
 
     group('AudioIn Client Tests', () {
@@ -300,6 +319,12 @@ void main() {
         final client = AudioInClient(name, channel);
         final result = await client.getStatus();
         expect(result, audioIn.statusResult);
+      });
+
+      test('getGeometries', () async {
+        final client = AudioInClient(name, channel);
+        final geometries = await client.getGeometries();
+        expect(geometries, audioIn.geometries);
       });
     });
   });

--- a/test/unit_test/components/audio_out_test.dart
+++ b/test/unit_test/components/audio_out_test.dart
@@ -62,6 +62,14 @@ class FakeAudioOut extends AudioOut {
     propertiesExtra = extra;
     return GetPropertiesResponse()..supportedCodecs.addAll([AudioCodec.mp3, AudioCodec.pcm16, AudioCodec.aac]);
   }
+
+  List<Geometry> geometries = [Geometry()..label = 'test'];
+
+  @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    this.extra = extra;
+    return geometries;
+  }
 }
 
 void main() {
@@ -152,6 +160,11 @@ void main() {
     test('getStatus', () async {
       final result = await audioOut.getStatus();
       expect(result, audioOut.statusResult);
+    });
+
+    test('getGeometries', () async {
+      final result = await audioOut.getGeometries();
+      expect(result, audioOut.geometries);
     });
   });
 
@@ -271,6 +284,12 @@ void main() {
         final response = await client.getStatus(GetStatusRequest()..name = name);
         expect(response.result.toMap(), audioOut.statusResult);
       });
+
+      test('getGeometries', () async {
+        final client = AudioOutServiceClient(channel);
+        final response = await client.getGeometries(GetGeometriesRequest()..name = name);
+        expect(response.geometries, audioOut.geometries);
+      });
     });
 
     group('AudioOut Client Tests', () {
@@ -344,6 +363,12 @@ void main() {
         final client = AudioOutClient(name, channel);
         final result = await client.getStatus();
         expect(result, audioOut.statusResult);
+      });
+
+      test('getGeometries', () async {
+        final client = AudioOutClient(name, channel);
+        final geometries = await client.getGeometries();
+        expect(geometries, audioOut.geometries);
       });
     });
   });

--- a/test/unit_test/components/base_test.dart
+++ b/test/unit_test/components/base_test.dart
@@ -2,7 +2,7 @@ import 'package:fixnum/fixnum.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:grpc/grpc.dart';
 import 'package:viam_sdk/src/components/base/service.dart';
-import 'package:viam_sdk/src/gen/common/v1/common.pb.dart' show GetStatusRequest;
+import 'package:viam_sdk/src/gen/common/v1/common.pb.dart' show Geometry, GetGeometriesRequest, GetStatusRequest;
 import 'package:viam_sdk/src/gen/component/base/v1/base.pbgrpc.dart';
 import 'package:viam_sdk/src/resource/manager.dart';
 import 'package:viam_sdk/src/utils.dart';
@@ -100,6 +100,14 @@ class FakeBase extends Base {
   Future<Map<String, dynamic>> getStatus() async {
     return statusResult;
   }
+
+  List<Geometry> geometries = [Geometry()..label = 'test'];
+
+  @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    this.extra = extra;
+    return geometries;
+  }
 }
 
 void main() {
@@ -192,6 +200,11 @@ void main() {
     test('getStatus', () async {
       final result = await base.getStatus();
       expect(result, base.statusResult);
+    });
+
+    test('getGeometries', () async {
+      final result = await base.getGeometries();
+      expect(result, base.geometries);
     });
 
     test('extra', () async {
@@ -358,6 +371,12 @@ void main() {
         expect(response.result.toMap(), base.statusResult);
       });
 
+      test('getGeometries', () async {
+        final client = BaseServiceClient(channel);
+        final response = await client.getGeometries(GetGeometriesRequest()..name = name);
+        expect(response.geometries, base.geometries);
+      });
+
       test('extra', () async {
         expect(base.extra, null);
 
@@ -466,6 +485,12 @@ void main() {
         final client = BaseClient(name, channel);
         final result = await client.getStatus();
         expect(result, base.statusResult);
+      });
+
+      test('getGeometries', () async {
+        final client = BaseClient(name, channel);
+        final geometries = await client.getGeometries();
+        expect(geometries, base.geometries);
       });
 
       test('extra', () async {

--- a/test/unit_test/components/board_test.dart
+++ b/test/unit_test/components/board_test.dart
@@ -123,6 +123,14 @@ class FakeBoard extends Board {
     final queue = tickCallbackMap[tick.pinName];
     queue?.add(tick);
   }
+
+  List<Geometry> geometries = [Geometry()..label = 'test'];
+
+  @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    this.extra = extra;
+    return geometries;
+  }
 }
 
 void main() {
@@ -203,6 +211,11 @@ void main() {
     test('getStatus', () async {
       final result = await board.getStatus();
       expect(result, board.statusResult);
+    });
+
+    test('getGeometries', () async {
+      final result = await board.getGeometries();
+      expect(result, board.geometries);
     });
 
     test('extra', () async {
@@ -397,6 +410,12 @@ void main() {
         expect(response.result.toMap(), board.statusResult);
       });
 
+      test('getGeometries', () async {
+        final client = BoardServiceClient(channel);
+        final response = await client.getGeometries(GetGeometriesRequest()..name = name);
+        expect(response.geometries, board.geometries);
+      });
+
       test('extra', () async {
         final client = BoardServiceClient(channel);
         expect(board.extra, null);
@@ -506,6 +525,12 @@ void main() {
         final client = BoardClient(name, channel);
         final result = await client.getStatus();
         expect(result, board.statusResult);
+      });
+
+      test('getGeometries', () async {
+        final client = BoardClient(name, channel);
+        final geometries = await client.getGeometries();
+        expect(geometries, board.geometries);
       });
 
       test('extra', () async {

--- a/test/unit_test/components/camera_test.dart
+++ b/test/unit_test/components/camera_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:grpc/grpc.dart';
 import 'package:viam_sdk/src/components/camera/service.dart';
-import 'package:viam_sdk/src/gen/common/v1/common.pb.dart' show GetStatusRequest;
+import 'package:viam_sdk/src/gen/common/v1/common.pb.dart' show Geometry, GetGeometriesRequest, GetStatusRequest;
 import 'package:viam_sdk/src/gen/component/camera/v1/camera.pbgrpc.dart';
 import 'package:viam_sdk/src/resource/manager.dart';
 import 'package:viam_sdk/src/utils.dart';
@@ -62,6 +62,14 @@ class FakeCamera extends Camera {
       metadata: ResponseMetadata(capturedAt: expectedCapturedAt),
     );
   }
+
+  List<Geometry> geometries = [Geometry()..label = 'test'];
+
+  @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    this.extra = extra;
+    return geometries;
+  }
 }
 
 void main() {
@@ -95,6 +103,11 @@ void main() {
     test('getStatus', () async {
       final result = await camera.getStatus();
       expect(result, camera.statusResult);
+    });
+
+    test('getGeometries', () async {
+      final result = await camera.getGeometries();
+      expect(result, camera.geometries);
     });
 
     test('getImages', () async {
@@ -181,6 +194,12 @@ void main() {
         expect(response.result.toMap(), camera.statusResult);
       });
 
+      test('getGeometries', () async {
+        final client = CameraServiceClient(channel);
+        final response = await client.getGeometries(GetGeometriesRequest()..name = name);
+        expect(response.geometries, camera.geometries);
+      });
+
       test('getImages', () async {
         final client = CameraServiceClient(channel);
 
@@ -253,6 +272,12 @@ void main() {
         final client = CameraClient(name, channel);
         final result = await client.getStatus();
         expect(result, camera.statusResult);
+      });
+
+      test('getGeometries', () async {
+        final client = CameraClient(name, channel);
+        final geometries = await client.getGeometries();
+        expect(geometries, camera.geometries);
       });
 
       test('getImages', () async {

--- a/test/unit_test/components/generic_test.dart
+++ b/test/unit_test/components/generic_test.dart
@@ -24,6 +24,13 @@ class FakeGeneric extends Generic {
   Future<Map<String, dynamic>> getStatus() async {
     return statusResult;
   }
+
+  List<Geometry> geometries = [Geometry()..label = 'test'];
+
+  @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    return geometries;
+  }
 }
 
 void main() {
@@ -44,6 +51,11 @@ void main() {
     test('getStatus', () async {
       final result = await generic.getStatus();
       expect(result, generic.statusResult);
+    });
+
+    test('getGeometries', () async {
+      final result = await generic.getGeometries();
+      expect(result, generic.geometries);
     });
   });
 
@@ -92,6 +104,12 @@ void main() {
         final response = await client.getStatus(GetStatusRequest()..name = name);
         expect(response.result.toMap(), generic.statusResult);
       });
+
+      test('getGeometries', () async {
+        final client = generic_pb.GenericServiceClient(channel);
+        final response = await client.getGeometries(GetGeometriesRequest()..name = name);
+        expect(response.geometries, generic.geometries);
+      });
     });
 
     group('Generic Client Tests', () {
@@ -106,6 +124,12 @@ void main() {
         final client = GenericClient(name, channel);
         final result = await client.getStatus();
         expect(result, generic.statusResult);
+      });
+
+      test('getGeometries', () async {
+        final client = GenericClient(name, channel);
+        final geometries = await client.getGeometries();
+        expect(geometries, generic.geometries);
       });
     });
   });

--- a/test/unit_test/components/gripper_test.dart
+++ b/test/unit_test/components/gripper_test.dart
@@ -79,6 +79,14 @@ class FakeGripper extends Gripper {
     goToInputsValues = values;
     this.extra = extra;
   }
+
+  List<Geometry> geometries = [Geometry()..label = 'test'];
+
+  @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    this.extra = extra;
+    return geometries;
+  }
 }
 
 void main() {
@@ -138,6 +146,11 @@ void main() {
     test('getStatus', () async {
       final result = await gripper.getStatus();
       expect(result, gripper.statusResult);
+    });
+
+    test('getGeometries', () async {
+      final result = await gripper.getGeometries();
+      expect(result, gripper.geometries);
     });
 
     test('extra', () async {
@@ -282,6 +295,12 @@ void main() {
         expect(response.result.toMap(), gripper.statusResult);
       });
 
+      test('getGeometries', () async {
+        final client = GripperServiceClient(channel);
+        final response = await client.getGeometries(GetGeometriesRequest()..name = name);
+        expect(response.geometries, gripper.geometries);
+      });
+
       test('extra', () async {
         expect(gripper.extra, null);
 
@@ -370,6 +389,12 @@ void main() {
         final client = GripperClient(name, channel);
         final result = await client.getStatus();
         expect(result, gripper.statusResult);
+      });
+
+      test('getGeometries', () async {
+        final client = GripperClient(name, channel);
+        final geometries = await client.getGeometries();
+        expect(geometries, gripper.geometries);
       });
 
       test('extra', () async {

--- a/test/unit_test/components/motor_test.dart
+++ b/test/unit_test/components/motor_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:grpc/grpc.dart';
 import 'package:viam_sdk/src/components/motor/service.dart';
-import 'package:viam_sdk/src/gen/common/v1/common.pb.dart' show GetStatusRequest;
+import 'package:viam_sdk/src/gen/common/v1/common.pb.dart' show Geometry, GetGeometriesRequest, GetStatusRequest;
 import 'package:viam_sdk/src/gen/component/motor/v1/motor.pbgrpc.dart';
 import 'package:viam_sdk/src/resource/manager.dart';
 import 'package:viam_sdk/src/utils.dart';
@@ -17,6 +17,7 @@ class FakeMotor extends Motor {
   bool powered = false;
   Map<String, dynamic>? extra;
   Map<String, dynamic> statusResult = {'status': 'ok'};
+  List<Geometry> geometries = [Geometry()..label = 'test'];
 
   @override
   String name;
@@ -97,6 +98,12 @@ class FakeMotor extends Motor {
   Future<void> stop({Map<String, dynamic>? extra}) async {
     this.extra = extra;
     isStopped = true;
+  }
+
+  @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    this.extra = extra;
+    return geometries;
   }
 }
 
@@ -197,6 +204,11 @@ void main() {
     test('getStatus', () async {
       final result = await motor.getStatus();
       expect(result, motor.statusResult);
+    });
+
+    test('getGeometries', () async {
+      final result = await motor.getGeometries();
+      expect(result, motor.geometries);
     });
 
     test('extra', () async {
@@ -382,6 +394,12 @@ void main() {
         expect(response.result.toMap(), motor.statusResult);
       });
 
+      test('getGeometries', () async {
+        final client = MotorServiceClient(channel);
+        final response = await client.getGeometries(GetGeometriesRequest()..name = name);
+        expect(response.geometries, motor.geometries);
+      });
+
       test('extra', () async {
         expect(motor.extra, null);
 
@@ -497,6 +515,12 @@ void main() {
         final client = MotorClient(name, channel);
         final result = await client.getStatus();
         expect(result, motor.statusResult);
+      });
+
+      test('getGeometries', () async {
+        final client = MotorClient(name, channel);
+        final geometries = await client.getGeometries();
+        expect(geometries, motor.geometries);
       });
 
       test('extra', () async {

--- a/test/unit_test/components/movement_sensor_test.dart
+++ b/test/unit_test/components/movement_sensor_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:grpc/grpc.dart';
 import 'package:viam_sdk/src/components/movement_sensor/service.dart';
-import 'package:viam_sdk/src/gen/common/v1/common.pb.dart' show GetStatusRequest;
+import 'package:viam_sdk/src/gen/common/v1/common.pb.dart' show Geometry, GetGeometriesRequest, GetStatusRequest;
 import 'package:viam_sdk/src/gen/component/movementsensor/v1/movementsensor.pbgrpc.dart';
 import 'package:viam_sdk/src/resource/manager.dart';
 import 'package:viam_sdk/src/utils.dart';
@@ -91,6 +91,14 @@ class FakeMovementSensor extends MovementSensor {
     this.extra = extra;
     return sensorReadings;
   }
+
+  List<Geometry> geometries = [Geometry()..label = 'test'];
+
+  @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    this.extra = extra;
+    return geometries;
+  }
 }
 
 void main() {
@@ -155,6 +163,11 @@ void main() {
     test('getStatus', () async {
       final result = await movementSensor.getStatus();
       expect(result, movementSensor.statusResult);
+    });
+
+    test('getGeometries', () async {
+      final result = await movementSensor.getGeometries();
+      expect(result, movementSensor.geometries);
     });
 
     test('extra', () async {
@@ -263,6 +276,12 @@ void main() {
         expect(response.result.toMap(), movementSensor.statusResult);
       });
 
+      test('getGeometries', () async {
+        final client = MovementSensorServiceClient(channel);
+        final response = await client.getGeometries(GetGeometriesRequest()..name = name);
+        expect(response.geometries, movementSensor.geometries);
+      });
+
       test('extra', () async {
         expect(movementSensor.extra, null);
 
@@ -353,6 +372,12 @@ void main() {
         final client = MovementSensorClient(name, channel);
         final result = await client.getStatus();
         expect(result, movementSensor.statusResult);
+      });
+
+      test('getGeometries', () async {
+        final client = MovementSensorClient(name, channel);
+        final geometries = await client.getGeometries();
+        expect(geometries, movementSensor.geometries);
       });
 
       test('extra', () async {

--- a/test/unit_test/components/sensor_test.dart
+++ b/test/unit_test/components/sensor_test.dart
@@ -37,6 +37,14 @@ class FakeSensor extends Sensor {
     this.extra = extra;
     return sensorReadings;
   }
+
+  List<Geometry> geometries = [Geometry()..label = 'test'];
+
+  @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    this.extra = extra;
+    return geometries;
+  }
 }
 
 void main() {
@@ -62,6 +70,11 @@ void main() {
     test('getStatus', () async {
       final result = await sensor.getStatus();
       expect(result, sensor.statusResult);
+    });
+
+    test('getGeometries', () async {
+      final result = await sensor.getGeometries();
+      expect(result, sensor.geometries);
     });
 
     test('extra', () async {
@@ -124,6 +137,12 @@ void main() {
         expect(response.result.toMap(), sensor.statusResult);
       });
 
+      test('getGeometries', () async {
+        final client = SensorServiceClient(channel);
+        final response = await client.getGeometries(GetGeometriesRequest()..name = name);
+        expect(response.geometries, sensor.geometries);
+      });
+
       test('extra', () async {
         expect(sensor.extra, null);
 
@@ -154,6 +173,12 @@ void main() {
         final client = SensorClient(name, channel);
         final result = await client.getStatus();
         expect(result, sensor.statusResult);
+      });
+
+      test('getGeometries', () async {
+        final client = SensorClient(name, channel);
+        final geometries = await client.getGeometries();
+        expect(geometries, sensor.geometries);
       });
 
       test('extra', () async {

--- a/test/unit_test/components/servo_test.dart
+++ b/test/unit_test/components/servo_test.dart
@@ -12,6 +12,7 @@ class FakeServo extends Servo {
   bool isStopped = true;
   Map<String, dynamic>? extra;
   Map<String, dynamic> statusResult = {'status': 'ok'};
+  List<Geometry> geometries = [Geometry()..label = 'test'];
 
   @override
   String name;
@@ -50,6 +51,12 @@ class FakeServo extends Servo {
   @override
   Future<Map<String, dynamic>> getStatus() async {
     return statusResult;
+  }
+
+  @override
+  Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra}) async {
+    this.extra = extra;
+    return geometries;
   }
 }
 
@@ -104,6 +111,11 @@ void main() {
     test('getStatus', () async {
       final result = await servo.getStatus();
       expect(result, servo.statusResult);
+    });
+
+    test('getGeometries', () async {
+      final result = await servo.getGeometries();
+      expect(result, servo.geometries);
     });
   });
 
@@ -189,6 +201,12 @@ void main() {
         final response = await client.getStatus(GetStatusRequest()..name = name);
         expect(response.result.toMap(), servo.statusResult);
       });
+
+      test('getGeometries', () async {
+        final client = ServoServiceClient(channel);
+        final response = await client.getGeometries(GetGeometriesRequest()..name = name);
+        expect(response.geometries, servo.geometries);
+      });
     });
     group('Servo Client Tests', () {
       test('move should move the servo to new given position', () async {
@@ -227,6 +245,12 @@ void main() {
         final client = ServoClient(servo.name, channel);
         final result = await client.getStatus();
         expect(result, servo.statusResult);
+      });
+
+      test('getGeometries', () async {
+        final client = ServoClient(servo.name, channel);
+        final geometries = await client.getGeometries();
+        expect(geometries, servo.geometries);
       });
     });
   });


### PR DESCRIPTION
## Summary

Part of the effort to expose `geometries` on every component that supports it (alongside `DoCommand`).

In the Flutter SDK, most components had an **unimplemented** `getGeometries` server handler (`throw UnimplementedError()`) and no client/interface method, so geometries could not be retrieved at all. This PR implements `getGeometries` end-to-end for every component whose API defines a `GetGeometries` RPC:

- audio input
- audio output
- base
- board
- camera
- generic
- gripper
- input controller
- motor
- movement sensor
- sensor
- servo

This brings them in line with **arm, encoder, and gantry**, which were already complete.

> Note: `button`, `power sensor`, and `switch` are intentionally excluded — their APIs do not define a `GetGeometries` RPC.

## Changes

For each component:
- **Interface** (`<name>.dart`): add `Future<List<Geometry>> getGeometries({Map<String, dynamic>? extra})`.
- **Client** (`client.dart`): implement the method by calling the `GetGeometries` RPC and returning `response.geometries`.
- **Service** (`service.dart`): implement the previously stubbed server handler, delegating to the resource.

The input controller client previously had a partial, non-`@override` `getGeometries` that returned the raw `GetGeometriesResponse`; it now returns `List<Geometry>` and is declared on the interface, consistent with every other component.

Unit tests were added for the fake, service, and client of each updated component (mirroring the existing arm/encoder/gantry geometries tests).

## Testing

- `flutter test test/unit_test/components/ --concurrency=1` → all 436 tests pass (the suite uses fixed ports and is flaky under the default parallel runner — unrelated to this change).
- `dart format --line-length=140 --set-exit-if-changed` → clean.
- `dart analyze ./lib` → no new issues.

Key: RSDK-11037

Co-authored by Claude agent for Jira.