### PR TITLE
AI update based on proto changes

### DIFF
--- a/lib/src/app/app.dart
+++ b/lib/src/app/app.dart
@@ -4,6 +4,8 @@ import 'package:fixnum/fixnum.dart';
 
 import '../../protos/app/packages.dart';
 import '../gen/app/v1/app.pbgrpc.dart';
+import '../gen/app/v1/app.pbenum.dart';
+import '../gen/app/v1/app.pb.dart' show LoginMethod, AllowedLoginMethods, DeprecatedStatus, RegistryItemBilling, RegistryItemCostByResource;
 import '../gen/common/v1/common.pb.dart';
 import '../gen/google/protobuf/timestamp.pb.dart';
 import '../utils.dart';
@@ -103,6 +105,7 @@ class AppClient {
     String? region,
     String? cid,
     FragmentImportList? defaultFragments,
+    AllowedLoginMethods? allowedLoginMethods,
   }) async {
     final request = UpdateOrganizationRequest()..organizationId = organizationId;
     if (name != null) request.name = name;
@@ -112,6 +115,7 @@ class AppClient {
     if (defaultFragments != null) {
       request.defaultFragments = defaultFragments;
     }
+    if (allowedLoginMethods != null) request.allowedLoginMethods = allowedLoginMethods;
     final UpdateOrganizationResponse response = await _client.updateOrganization(request);
     return response.organization;
   }
@@ -710,11 +714,13 @@ class AppClient {
     String? organizationId,
     String? searchTerm,
     String? pageToken,
+    bool? showOwnedDeprecated,
   }) async {
     final request = ListRegistryItemsRequest(types: types, visibilities: visibilities, platforms: platforms, statuses: statuses)
       ..organizationId = organizationId ?? ''
       ..searchTerm = searchTerm ?? ''
       ..pageToken = pageToken ?? '';
+    if (showOwnedDeprecated != null) request.showOwnedDeprecated = showOwnedDeprecated;
     final ListRegistryItemsResponse response = await _client.listRegistryItems(request);
     return response.items;
   }
@@ -725,6 +731,44 @@ class AppClient {
   Future<void> deleteRegistryItem(String itemId) async {
     final request = DeleteRegistryItemRequest()..itemId = itemId;
     await _client.deleteRegistryItem(request);
+  }
+
+  /// Deprecate a [RegistryItem]
+  ///
+  /// For more information, see [Fleet Management API](https://docs.viam.com/appendix/apis/fleet/).
+  Future<void> deprecateRegistryItem(String itemId, {String? message}) async {
+    final request = DeprecateRegistryItemRequest()..itemId = itemId;
+    if (message != null) request.message = message;
+    await _client.deprecateRegistryItem(request);
+  }
+
+  /// Undeprecate a [RegistryItem]
+  ///
+  /// For more information, see [Fleet Management API](https://docs.viam.com/appendix/apis/fleet/).
+  Future<void> undeprecateRegistryItem(String itemId) async {
+    final request = UndeprecateRegistryItemRequest()..itemId = itemId;
+    await _client.undeprecateRegistryItem(request);
+  }
+
+  /// Deprecate a [RegistryItemVersion]
+  ///
+  /// For more information, see [Fleet Management API](https://docs.viam.com/appendix/apis/fleet/).
+  Future<void> deprecateRegistryItemVersion(String itemId, String version, {String? message}) async {
+    final request = DeprecateRegistryItemVersionRequest()
+      ..itemId = itemId
+      ..version = version;
+    if (message != null) request.message = message;
+    await _client.deprecateRegistryItemVersion(request);
+  }
+
+  /// Undeprecate a [RegistryItemVersion]
+  ///
+  /// For more information, see [Fleet Management API](https://docs.viam.com/appendix/apis/fleet/).
+  Future<void> undeprecateRegistryItemVersion(String itemId, String version) async {
+    final request = UndeprecateRegistryItemVersionRequest()
+      ..itemId = itemId
+      ..version = version;
+    await _client.undeprecateRegistryItemVersion(request);
   }
 
   /// Create a [Module]

--- a/lib/src/app/data.dart
+++ b/lib/src/app/data.dart
@@ -14,6 +14,7 @@ import '../gen/google/protobuf/any.pb.dart';
 import '../gen/google/protobuf/timestamp.pb.dart';
 import '../media/image.dart';
 import '../utils.dart';
+import 'package:viam_sdk/src/gen/app/data/v1/data.pb.dart' show BinaryData;
 
 /// {@category App}
 typedef DatabaseConnection = GetDatabaseConnectionResponse;
@@ -298,7 +299,7 @@ class DataClient {
   ///    sqlQuery
   ///  });
   ///
-  ///  final limit = BsonCodec.serialize({"\$limit": 1});
+  ///  final limit = BsonCodec.serialize({"$limit": 1});
   ///
   ///  final pipeline = [query.byteList, sort.byteList, limit.byteList];
   ///  _responseData = await dataClient.tabularDataByMql(
@@ -1749,6 +1750,35 @@ class DataClient {
       request.pipelineName = pipelineName;
     }
     await _dataClient.deleteIndex(request);
+  }
+
+  /// Returns a list of binary data for a given sequence ID.
+  ///
+  /// The data will be paginated into pages of `pageSize` items, and the `pageToken` will be included in
+  /// the returned response.
+  ///
+  /// ```
+  /// _viam = await Viam.withApiKey(
+  ///      dotenv.env['API_KEY_ID'] ?? '',
+  ///      dotenv.env['API_KEY'] ?? ''
+  ///  );
+  ///  final dataClient = _viam.dataClient;
+  ///
+  ///  try {
+  ///    final sequenceId = '<YOUR-SEQUENCE-ID>';
+  ///    final response = await dataClient.getSequenceBinaryData(sequenceId);
+  ///    print('Successfully retrieved sequence binary data: ${response.length} items');
+  ///  } catch (e) {
+  ///    print('Error retrieving sequence binary data: $e');
+  ///  }
+  /// ```
+  /// For more information, see [Data Client API](https://docs.viam.com/dev/reference/apis/data-client/).
+  Future<List<BinaryData>> getSequenceBinaryData(String sequenceId, {String? pageToken, int? pageSize}) async {
+    final request = GetSequenceBinaryDataRequest()..sequenceId = sequenceId;
+    if (pageToken != null) request.pageToken = pageToken;
+    if (pageSize != null) request.pageSize = pageSize;
+    final response = await _dataClient.getSequenceBinaryData(request);
+    return response.data;
   }
 }
 

--- a/lib/src/robot/client.dart
+++ b/lib/src/robot/client.dart
@@ -15,6 +15,10 @@ import '../resource/registry.dart';
 import '../rpc/dial.dart';
 import '../rpc/web_rtc/web_rtc_client.dart';
 import 'sessions_client.dart';
+import '../gen/app/datasync/v1/data_sync.pb.dart' as $7;
+import '../gen/app/packages/v1/packages.pbenum.dart' as $1;
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import '../gen/robot/v1/robot.pb.dart' show ModuleStatus, PackageStatus, UploadDataFromPathRequest, UploadDataFromPathResponse;
 
 /// {@category Viam SDK}
 typedef CloudMetadata = rpb.GetCloudMetadataResponse;
@@ -333,5 +337,38 @@ class RobotClient {
     final request = rpb.GetMachineStatusRequest();
     final response = await _client.getMachineStatus(request);
     return response;
+  }
+
+  /// Uploads data from a specified path on the robot to Viam's Data Manager.
+  ///
+  /// This method allows you to upload files or folders from the robot's local file system.
+  /// Optional metadata and extra arguments can be provided.
+  ///
+  /// ```
+  /// // Example: Upload a file from the robot's /tmp directory
+  /// final response = await robotClient.uploadDataFromPath(
+  ///   '/tmp/my_robot_data.txt',
+  ///   uploadMetadata: UploadMetadata(
+  ///     partId: 'my-robot-part-id',
+  ///     type: DataType.DATA_TYPE_FILE,
+  ///     fileName: 'uploaded_data.txt',
+  ///     fileExtension: '.txt',
+  ///   ),
+  ///   extra: {'custom_key': 'custom_value'},
+  /// );
+  /// print('Files uploaded: ${response.filesUploaded}');
+  /// print('Bytes uploaded: ${response.bytesUploaded}');
+  /// ```
+  ///
+  /// For more information, see the [Robot API](https://docs.viam.com/appendix/apis/robot/).
+  Future<UploadDataFromPathResponse> uploadDataFromPath(String path, {$7.UploadMetadata? uploadMetadata, Map<String, dynamic>? extra}) async {
+    final request = UploadDataFromPathRequest()..path = path;
+    if (uploadMetadata != null) {
+      request.uploadMetadata = uploadMetadata;
+    }
+    if (extra != null) {
+      request.extra = extra.toStruct();
+    }
+    return await _client.uploadDataFromPath(request);
   }
 }

--- a/test/unit_test/app/app_client_test.dart
+++ b/test/unit_test/app/app_client_test.dart
@@ -10,6 +10,8 @@ import 'package:viam_sdk/src/gen/app/v1/app.pbgrpc.dart';
 import 'package:viam_sdk/src/gen/google/protobuf/struct.pb.dart';
 import 'package:viam_sdk/src/gen/google/protobuf/timestamp.pb.dart';
 import 'package:viam_sdk/viam_sdk.dart' hide APIKey;
+import 'package:viam_sdk/src/gen/app/v1/app.pbenum.dart';
+import 'package:viam_sdk/src/gen/app/v1/app.pb.dart' show AllowedLoginMethods, DeprecatedStatus, RegistryItemBilling, RegistryItemCostByResource;
 
 import '../mocks/mock_response_future.dart';
 import '../mocks/service_clients_mocks.mocks.dart';
@@ -145,8 +147,21 @@ void main() {
       ).thenAnswer((_) => MockResponseFuture.value(UpdateOrganizationResponse()..organization = expected));
       final fragmentList = [FragmentImport()..fragmentId = 'fragmentId'];
       final fragmentImportList = FragmentImportList()..fragments.addAll(fragmentList);
-      final response = await appClient.updateOrganization('organizationId', defaultFragments: fragmentImportList);
+      final response = await appClient.updateOrganization(
+        'organizationId',
+        defaultFragments: fragmentImportList,
+        allowedLoginMethods: AllowedLoginMethods()..methods.add(LoginMethod.LOGIN_METHOD_PASSWORD),
+      );
       expect(response, equals(expected));
+      verify(serviceClient.updateOrganization(
+        argThat(
+          isA<UpdateOrganizationRequest>().having(
+            (req) => req.allowedLoginMethods,
+            'allowedLoginMethods',
+            AllowedLoginMethods()..methods.add(LoginMethod.LOGIN_METHOD_PASSWORD),
+          ),
+        ),
+      )).called(1);
     });
 
     test('deleteOrganization', () async {
@@ -745,8 +760,18 @@ void main() {
         [Visibility.VISIBILITY_UNSPECIFIED],
         ['platforms'],
         [RegistryItemStatus.REGISTRY_ITEM_STATUS_UNSPECIFIED],
+        showOwnedDeprecated: true,
       );
       expect(response, equals(expected));
+      verify(serviceClient.listRegistryItems(
+        argThat(
+          isA<ListRegistryItemsRequest>().having(
+            (req) => req.showOwnedDeprecated,
+            'showOwnedDeprecated',
+            true,
+          ),
+        ),
+      )).called(1);
     });
 
     test('deleteRegistryItem', () async {
@@ -754,6 +779,34 @@ void main() {
       when(serviceClient.deleteRegistryItem(any)).thenAnswer((_) => MockResponseFuture.value(expected));
       await appClient.deleteRegistryItem('itemId');
       verify(serviceClient.deleteRegistryItem(any)).called(1);
+    });
+
+    test('deprecateRegistryItem', () async {
+      final expected = DeprecateRegistryItemResponse();
+      when(serviceClient.deprecateRegistryItem(any)).thenAnswer((_) => MockResponseFuture.value(expected));
+      await appClient.deprecateRegistryItem('itemId', message: 'This item is deprecated');
+      verify(serviceClient.deprecateRegistryItem(argThat(isA<DeprecateRegistryItemRequest>().having((req) => req.itemId, 'itemId', 'itemId').having((req) => req.message, 'message', 'This item is deprecated')))).called(1);
+    });
+
+    test('undeprecateRegistryItem', () async {
+      final expected = UndeprecateRegistryItemResponse();
+      when(serviceClient.undeprecateRegistryItem(any)).thenAnswer((_) => MockResponseFuture.value(expected));
+      await appClient.undeprecateRegistryItem('itemId');
+      verify(serviceClient.undeprecateRegistryItem(argThat(isA<UndeprecateRegistryItemRequest>().having((req) => req.itemId, 'itemId', 'itemId')))).called(1);
+    });
+
+    test('deprecateRegistryItemVersion', () async {
+      final expected = DeprecateRegistryItemVersionResponse();
+      when(serviceClient.deprecateRegistryItemVersion(any)).thenAnswer((_) => MockResponseFuture.value(expected));
+      await appClient.deprecateRegistryItemVersion('itemId', '1.0.0', message: 'This version is deprecated');
+      verify(serviceClient.deprecateRegistryItemVersion(argThat(isA<DeprecateRegistryItemVersionRequest>().having((req) => req.itemId, 'itemId', 'itemId').having((req) => req.version, 'version', '1.0.0').having((req) => req.message, 'message', 'This version is deprecated')))).called(1);
+    });
+
+    test('undeprecateRegistryItemVersion', () async {
+      final expected = UndeprecateRegistryItemVersionResponse();
+      when(serviceClient.undeprecateRegistryItemVersion(any)).thenAnswer((_) => MockResponseFuture.value(expected));
+      await appClient.undeprecateRegistryItemVersion('itemId', '1.0.0');
+      verify(serviceClient.undeprecateRegistryItemVersion(argThat(isA<UndeprecateRegistryItemVersionRequest>().having((req) => req.itemId, 'itemId', 'itemId').having((req) => req.version, 'version', '1.0.0')))).called(1);
     });
 
     test('createModule', () async {

--- a/test/unit_test/app/data_client_test.dart
+++ b/test/unit_test/app/data_client_test.dart
@@ -609,6 +609,14 @@ void main() {
         await dataClient.deleteIndex(orgId, collectionType, indexName);
         verify(serviceClient.deleteIndex(any)).called(1);
       });
+
+      test('getSequenceBinaryData', () async {
+        final expectedBinaryData = [BinaryData()..binary = [1, 2, 3], BinaryData()..binary = [4, 5, 6]];
+        when(serviceClient.getSequenceBinaryData(any)).thenAnswer((_) => MockResponseFuture.value(GetSequenceBinaryDataResponse()..data.addAll(expectedBinaryData)..nextPageToken = 'nextPage'));
+        final response = await dataClient.getSequenceBinaryData('sequenceId', pageToken: 'token', pageSize: 10);
+        expect(response, equals(expectedBinaryData));
+        verify(serviceClient.getSequenceBinaryData(argThat(isA<GetSequenceBinaryDataRequest>().having((req) => req.sequenceId, 'sequenceId', 'sequenceId').having((req) => req.pageToken, 'pageToken', 'token').having((req) => req.pageSize, 'pageSize', 10)))).called(1);
+      });
     });
 
     group('DataSync Tests', () {

--- a/test/unit_test/robot/client_test.dart
+++ b/test/unit_test/robot/client_test.dart
@@ -1,5 +1,7 @@
+import 'package:fixnum/fixnum.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:viam_sdk/src/gen/common/v1/common.pb.dart' as common_pb;
 import 'package:viam_sdk/src/gen/robot/v1/robot.pb.dart';
 import 'package:viam_sdk/viam_sdk.dart';
 
@@ -29,7 +31,7 @@ void main() {
     test('sends moduleName for local modules', () async {
       when(serviceClient.restartModule(any)).thenAnswer((_) => MockResponseFuture.value(RestartModuleResponse()));
 
-      await robotClient.restartModule(moduleName: 'my-local-module');
+      await robotModuleClient.restartModule(moduleName: 'my-local-module');
 
       final captured = verify(serviceClient.restartModule(captureAny)).captured.single as RestartModuleRequest;
       expect(captured.moduleName, equals('my-local-module'));
@@ -44,6 +46,56 @@ void main() {
     test('throws when both moduleId and moduleName are provided', () async {
       expect(() => robotClient.restartModule(moduleId: 'a', moduleName: 'b'), throwsException);
       verifyNever(serviceClient.restartModule(any));
+    });
+  });
+
+  group('RobotClient.getMachineStatus', () {
+    test('gets machine status', () async {
+      final expected = GetMachineStatusResponse()
+        ..resources.addAll([ResourceStatus()..id = common_pb.ResourceName()..status = ResourceStatus_State.STATE_READY])
+        ..config = ConfigStatus()
+        ..state = GetMachineStatusResponse_State.STATE_RUNNING
+        ..jobStatuses.addAll([JobStatus()..id = 'jobId'])
+        ..modules.addAll([ModuleStatus()..moduleName = 'module1'..state = ModuleStatus_State.STATE_READY])
+        ..packages.addAll([PackageStatus()..name = 'package1'..type = PackageType.PACKAGE_TYPE_MODULE..state = PackageStatus_State.STATE_READY]);
+
+      when(serviceClient.getMachineStatus(any)).thenAnswer((_) => MockResponseFuture.value(expected));
+
+      final response = await robotClient.getMachineStatus();
+
+      expect(response.resources.length, 1);
+      expect(response.resources.first.id, common_pb.ResourceName());
+      expect(response.resources.first.status, ResourceStatus_State.STATE_READY);
+      expect(response.config, ConfigStatus());
+      expect(response.state, GetMachineStatusResponse_State.STATE_RUNNING);
+      expect(response.jobStatuses.length, 1);
+      expect(response.jobStatuses.first.id, 'jobId');
+      expect(response.modules.length, 1);
+      expect(response.modules.first.moduleName, 'module1');
+      expect(response.modules.first.state, ModuleStatus_State.STATE_READY);
+      expect(response.packages.length, 1);
+      expect(response.packages.first.name, 'package1');
+      expect(response.packages.first.type, PackageType.PACKAGE_TYPE_MODULE);
+      expect(response.packages.first.state, PackageStatus_State.STATE_READY);
+    });
+  });
+
+  group('RobotClient.uploadDataFromPath', () {
+    test('uploads data from path', () async {
+      final expected = UploadDataFromPathResponse()..filesUploaded = Int64(1)..bytesUploaded = Int64(100);
+      when(serviceClient.uploadDataFromPath(any)).thenAnswer((_) => MockResponseFuture.value(expected));
+
+      final uploadMetadata = UploadMetadata()..partId = 'partId'..fileName = 'test.txt';
+      final extra = {'key': 'value'};
+      final response = await robotClient.uploadDataFromPath('path/to/file.txt', uploadMetadata: uploadMetadata, extra: extra);
+
+      expect(response, equals(expected));
+      verify(serviceClient.uploadDataFromPath(argThat(
+        isA<UploadDataFromPathRequest>()
+            .having((req) => req.path, 'path', 'path/to/file.txt')
+            .having((req) => req.uploadMetadata.partId, 'uploadMetadata.partId', 'partId')
+            .having((req) => req.extra.fields['key']!.stringValue, 'extra.key', 'value'),
+      ))).called(1);
     });
   });
 }

--- a/test/unit_test/services/vision_test.dart
+++ b/test/unit_test/services/vision_test.dart
@@ -66,10 +66,11 @@ void main() {
     });
 
     test('properties', () async {
-      final expected = GetPropertiesResponse(classificationsSupported: true);
+      final expected = GetPropertiesResponse(classificationsSupported: true, defaultCamera: 'camera1');
       when(serviceClient.getProperties(any, options: anyNamed('options'))).thenAnswer((_) => MockResponseFuture.value(expected));
       final response = await client.properties();
       expect(response, equals(expected));
+      expect(response.defaultCamera, 'camera1');
     });
 
     test('getObjectPointClouds', () async {


### PR DESCRIPTION
This is an AI-generated PR to update the SDK based on proto changes. The AI may make mistakes so review carefully.

**Summary of Changes:**
This PR introduces several new features and improvements across Viam SDK clients:

*   **Build Service:** Adds the ability to start builds directly from source uploads via the new `StartSourceUploadBuild` RPC.
*   **Data Service:** Introduces `getSequenceBinaryData` to retrieve binary data associated with sequences, supporting pagination.
*   **App Service:**
    *   Enhances organization management by allowing configuration of allowed login methods (e.g., password, Google, GitHub).
    *   Adds functionality to deprecate and undeprecate registry items and their specific versions, providing better lifecycle management.
    *   Introduces a `showOwnedDeprecated` filter for listing registry items.
    *   Tracks the minimum required `viam-server` version for modules.
*   **Robot Service:**
    *   Implements `uploadDataFromPath` to allow uploading files and directories from the robot's filesystem, with support for metadata and additional arguments.
    *   Enhances `getMachineStatus` to provide detailed status information for modules (including state, errors, and failures) and packages (including download progress and state).
*   **Vision Service:** The `GetPropertiesResponse` now includes the `defaultCamera` used by the service.