### PR TITLE
Add NavigationClient for the navigation service

### DIFF
--- a/lib/src/resource/registry.dart
+++ b/lib/src/resource/registry.dart
@@ -51,6 +51,7 @@ class Registry {
     registerSubtype(ResourceRegistration(Switch.subtype, (name, channel) => SwitchClient(name, channel)));
     registerSubtype(ResourceRegistration(DiscoveryClient.subtype, (name, channel) => DiscoveryClient(name, channel)));
     registerSubtype(ResourceRegistration(GenericServiceClient.subtype, (name, channel) => GenericServiceClient(name, channel)));
+    registerSubtype(ResourceRegistration(NavigationClient.subtype, (name, channel) => NavigationClient(name, channel)));
     registerSubtype(ResourceRegistration(VisionClient.subtype, (name, channel) => VisionClient(name, channel)));
   }
 

--- a/lib/src/services/navigation.dart
+++ b/lib/src/services/navigation.dart
@@ -97,8 +97,8 @@ class NavigationClient extends Resource with RPCDebugLoggerMixin implements Reso
   /// Get information about the navigation service's properties, including its [MapType].
   ///
   /// For more information, see the [navigation service docs](https://docs.viam.com/dev/reference/apis/services/navigation/#getproperties).
-  Future<NavigationProperties> getProperties({Map<String, dynamic>? extra}) async {
-    final request = GetPropertiesRequest(name: name, extra: extra?.toStruct());
+  Future<NavigationProperties> getProperties() async {
+    final request = GetPropertiesRequest(name: name);
     return await client.getProperties(request, options: callOptions);
   }
 

--- a/lib/src/services/navigation.dart
+++ b/lib/src/services/navigation.dart
@@ -1,0 +1,125 @@
+import 'package:grpc/grpc_connection_interface.dart';
+
+import '../../protos/common/common.dart' as common_pb;
+import '../../protos/service/navigation.dart';
+import '../resource/base.dart';
+import '../robot/client.dart';
+import '../utils.dart';
+
+/// {@category Viam SDK}
+/// The navigation service's supported features and settings
+typedef NavigationProperties = GetPropertiesResponse;
+
+/// {@category Services}
+/// A client for the `navigation` service.
+class NavigationClient extends Resource with RPCDebugLoggerMixin implements ResourceRPCClient {
+  static const Subtype subtype = Subtype(resourceNamespaceRDK, resourceTypeService, 'navigation');
+
+  @override
+  final String name;
+
+  @override
+  ClientChannelBase channel;
+
+  @override
+  NavigationServiceClient get client => NavigationServiceClient(channel);
+
+  NavigationClient(this.name, this.channel);
+
+  /// Get the [Mode] the service is operating in.
+  ///
+  /// For more information, see the [navigation service docs](https://docs.viam.com/dev/reference/apis/services/navigation/#getmode).
+  Future<Mode> getMode({Map<String, dynamic>? extra}) async {
+    final request = GetModeRequest(name: name, extra: extra?.toStruct());
+    final response = await client.getMode(request, options: callOptions);
+    return response.mode;
+  }
+
+  /// Set the [Mode] the service is operating in.
+  ///
+  /// For more information, see the [navigation service docs](https://docs.viam.com/dev/reference/apis/services/navigation/#setmode).
+  Future<void> setMode(Mode mode, {Map<String, dynamic>? extra}) async {
+    final request = SetModeRequest(name: name, mode: mode, extra: extra?.toStruct());
+    await client.setMode(request, options: callOptions);
+  }
+
+  /// Get the current location of the robot as a [common_pb.GeoPoint] along with its compass heading.
+  ///
+  /// For more information, see the [navigation service docs](https://docs.viam.com/dev/reference/apis/services/navigation/#getlocation).
+  Future<GetLocationResponse> getLocation({Map<String, dynamic>? extra}) async {
+    final request = GetLocationRequest(name: name, extra: extra?.toStruct());
+    return await client.getLocation(request, options: callOptions);
+  }
+
+  /// Get an array of [Waypoint]s currently in the service's data storage.
+  ///
+  /// For more information, see the [navigation service docs](https://docs.viam.com/dev/reference/apis/services/navigation/#getwaypoints).
+  Future<List<Waypoint>> getWaypoints({Map<String, dynamic>? extra}) async {
+    final request = GetWaypointsRequest(name: name, extra: extra?.toStruct());
+    final response = await client.getWaypoints(request, options: callOptions);
+    return response.waypoints;
+  }
+
+  /// Add a [common_pb.GeoPoint] to the service's data storage of waypoints.
+  ///
+  /// For more information, see the [navigation service docs](https://docs.viam.com/dev/reference/apis/services/navigation/#addwaypoint).
+  Future<void> addWaypoint(common_pb.GeoPoint location, {Map<String, dynamic>? extra}) async {
+    final request = AddWaypointRequest(name: name, location: location, extra: extra?.toStruct());
+    await client.addWaypoint(request, options: callOptions);
+  }
+
+  /// Remove a [Waypoint] from the service's data storage by its [id].
+  ///
+  /// For more information, see the [navigation service docs](https://docs.viam.com/dev/reference/apis/services/navigation/#removewaypoint).
+  Future<void> removeWaypoint(String id, {Map<String, dynamic>? extra}) async {
+    final request = RemoveWaypointRequest(name: name, id: id, extra: extra?.toStruct());
+    await client.removeWaypoint(request, options: callOptions);
+  }
+
+  /// Get an array of [common_pb.GeoGeometry]s representing obstacles that the service is aware of.
+  ///
+  /// For more information, see the [navigation service docs](https://docs.viam.com/dev/reference/apis/services/navigation/#getobstacles).
+  Future<List<common_pb.GeoGeometry>> getObstacles({Map<String, dynamic>? extra}) async {
+    final request = GetObstaclesRequest(name: name, extra: extra?.toStruct());
+    final response = await client.getObstacles(request, options: callOptions);
+    return response.obstacles;
+  }
+
+  /// Get an array of [Path]s representing the paths the service is aware of.
+  ///
+  /// For more information, see the [navigation service docs](https://docs.viam.com/dev/reference/apis/services/navigation/#getpaths).
+  Future<List<Path>> getPaths({Map<String, dynamic>? extra}) async {
+    final request = GetPathsRequest(name: name, extra: extra?.toStruct());
+    final response = await client.getPaths(request, options: callOptions);
+    return response.paths;
+  }
+
+  /// Get information about the navigation service's properties, including its [MapType].
+  ///
+  /// For more information, see the [navigation service docs](https://docs.viam.com/dev/reference/apis/services/navigation/#getproperties).
+  Future<NavigationProperties> getProperties({Map<String, dynamic>? extra}) async {
+    final request = GetPropertiesRequest(name: name, extra: extra?.toStruct());
+    return await client.getProperties(request, options: callOptions);
+  }
+
+  @override
+  Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) async {
+    final request = common_pb.DoCommandRequest()
+      ..name = name
+      ..command = command.toStruct();
+    final response = await client.doCommand(request, options: callOptions);
+    return response.result.toMap();
+  }
+
+  /// Get the [common_pb.ResourceName] for this [NavigationClient] with the given [name]
+  ///
+  /// For more information, see the [navigation service docs](https://docs.viam.com/dev/reference/apis/services/navigation/#getresourcename).
+  static common_pb.ResourceName getResourceName(String name) {
+    return NavigationClient.subtype.getResourceName(name);
+  }
+
+  /// Get the [NavigationClient] named [name] from the provided robot.
+  static NavigationClient fromRobot(RobotClient robot, String name) {
+    return robot.getResource(NavigationClient.getResourceName(name));
+  }
+}

--- a/lib/viam_sdk.dart
+++ b/lib/viam_sdk.dart
@@ -67,6 +67,7 @@ export 'src/rpc/dial.dart';
 /// Services
 export 'src/services/discovery.dart';
 export 'src/services/generic.dart';
+export 'src/services/navigation.dart';
 export 'src/services/vision.dart';
 
 /// Misc

--- a/test/unit_test/mocks/service_clients_mocks.dart
+++ b/test/unit_test/mocks/service_clients_mocks.dart
@@ -10,6 +10,7 @@ import 'package:viam_sdk/src/gen/provisioning/v1/provisioning.pbgrpc.dart';
 import 'package:viam_sdk/src/gen/robot/v1/robot.pbgrpc.dart';
 import 'package:viam_sdk/src/gen/service/discovery/v1/discovery.pbgrpc.dart';
 import 'package:viam_sdk/src/gen/service/generic/v1/generic.pbgrpc.dart';
+import 'package:viam_sdk/src/gen/service/navigation/v1/navigation.pbgrpc.dart';
 import 'package:viam_sdk/src/gen/service/video/v1/video.pbgrpc.dart';
 import 'package:viam_sdk/src/gen/service/vision/v1/vision.pbgrpc.dart';
 
@@ -21,6 +22,7 @@ import 'package:viam_sdk/src/gen/service/vision/v1/vision.pbgrpc.dart';
   MockSpec<DataServiceClient>(),
   MockSpec<ProvisioningServiceClient>(),
   MockSpec<VisionServiceClient>(),
+  MockSpec<NavigationServiceClient>(),
   MockSpec<BillingServiceClient>(),
   MockSpec<MLTrainingServiceClient>(),
   MockSpec<DatasetServiceClient>(),

--- a/test/unit_test/mocks/service_clients_mocks.mocks.dart
+++ b/test/unit_test/mocks/service_clients_mocks.mocks.dart
@@ -38,6 +38,10 @@ import 'package:viam_sdk/src/gen/service/generic/v1/generic.pbgrpc.dart'
     as _i29;
 import 'package:viam_sdk/src/gen/service/video/v1/video.pb.dart' as _i31;
 import 'package:viam_sdk/src/gen/service/video/v1/video.pbgrpc.dart' as _i30;
+import 'package:viam_sdk/src/gen/service/navigation/v1/navigation.pb.dart'
+    as _i33;
+import 'package:viam_sdk/src/gen/service/navigation/v1/navigation.pbgrpc.dart'
+    as _i32;
 import 'package:viam_sdk/src/gen/service/vision/v1/vision.pb.dart' as _i19;
 import 'package:viam_sdk/src/gen/service/vision/v1/vision.pbgrpc.dart' as _i18;
 
@@ -6718,6 +6722,456 @@ class MockVisionServiceClient extends _i1.Mock
           ),
         ),
       ) as _i4.ResponseFuture<_i19.CaptureAllFromCameraResponse>);
+
+  @override
+  _i4.ResponseFuture<_i20.DoCommandResponse> doCommand(
+    _i20.DoCommandRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #doCommand,
+          [request],
+          {#options: options},
+        ),
+        returnValue: _FakeResponseFuture_2<_i20.DoCommandResponse>(
+          this,
+          Invocation.method(
+            #doCommand,
+            [request],
+            {#options: options},
+          ),
+        ),
+        returnValueForMissingStub:
+            _FakeResponseFuture_2<_i20.DoCommandResponse>(
+          this,
+          Invocation.method(
+            #doCommand,
+            [request],
+            {#options: options},
+          ),
+        ),
+      ) as _i4.ResponseFuture<_i20.DoCommandResponse>);
+
+  @override
+  _i4.ResponseFuture<_i20.GetStatusResponse> getStatus(
+    _i20.GetStatusRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getStatus,
+          [request],
+          {#options: options},
+        ),
+        returnValue: _FakeResponseFuture_2<_i20.GetStatusResponse>(
+          this,
+          Invocation.method(
+            #getStatus,
+            [request],
+            {#options: options},
+          ),
+        ),
+        returnValueForMissingStub:
+            _FakeResponseFuture_2<_i20.GetStatusResponse>(
+          this,
+          Invocation.method(
+            #getStatus,
+            [request],
+            {#options: options},
+          ),
+        ),
+      ) as _i4.ResponseFuture<_i20.GetStatusResponse>);
+
+  @override
+  _i3.ClientCall<Q, R> $createCall<Q, R>(
+    _i7.ClientMethod<Q, R>? method,
+    _i6.Stream<Q>? requests, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #$createCall,
+          [
+            method,
+            requests,
+          ],
+          {#options: options},
+        ),
+        returnValue: _FakeClientCall_1<Q, R>(
+          this,
+          Invocation.method(
+            #$createCall,
+            [
+              method,
+              requests,
+            ],
+            {#options: options},
+          ),
+        ),
+        returnValueForMissingStub: _FakeClientCall_1<Q, R>(
+          this,
+          Invocation.method(
+            #$createCall,
+            [
+              method,
+              requests,
+            ],
+            {#options: options},
+          ),
+        ),
+      ) as _i3.ClientCall<Q, R>);
+
+  @override
+  _i4.ResponseFuture<R> $createUnaryCall<Q, R>(
+    _i7.ClientMethod<Q, R>? method,
+    Q? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #$createUnaryCall,
+          [
+            method,
+            request,
+          ],
+          {#options: options},
+        ),
+        returnValue: _FakeResponseFuture_2<R>(
+          this,
+          Invocation.method(
+            #$createUnaryCall,
+            [
+              method,
+              request,
+            ],
+            {#options: options},
+          ),
+        ),
+        returnValueForMissingStub: _FakeResponseFuture_2<R>(
+          this,
+          Invocation.method(
+            #$createUnaryCall,
+            [
+              method,
+              request,
+            ],
+            {#options: options},
+          ),
+        ),
+      ) as _i4.ResponseFuture<R>);
+
+  @override
+  _i4.ResponseStream<R> $createStreamingCall<Q, R>(
+    _i7.ClientMethod<Q, R>? method,
+    _i6.Stream<Q>? requests, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #$createStreamingCall,
+          [
+            method,
+            requests,
+          ],
+          {#options: options},
+        ),
+        returnValue: _FakeResponseStream_3<R>(
+          this,
+          Invocation.method(
+            #$createStreamingCall,
+            [
+              method,
+              requests,
+            ],
+            {#options: options},
+          ),
+        ),
+        returnValueForMissingStub: _FakeResponseStream_3<R>(
+          this,
+          Invocation.method(
+            #$createStreamingCall,
+            [
+              method,
+              requests,
+            ],
+            {#options: options},
+          ),
+        ),
+      ) as _i4.ResponseStream<R>);
+}
+
+/// A class which mocks [NavigationServiceClient].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockNavigationServiceClient extends _i1.Mock
+    implements _i32.NavigationServiceClient {
+  @override
+  _i4.ResponseFuture<_i33.GetModeResponse> getMode(
+    _i33.GetModeRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getMode,
+          [request],
+          {#options: options},
+        ),
+        returnValue: _FakeResponseFuture_2<_i33.GetModeResponse>(
+          this,
+          Invocation.method(
+            #getMode,
+            [request],
+            {#options: options},
+          ),
+        ),
+        returnValueForMissingStub: _FakeResponseFuture_2<_i33.GetModeResponse>(
+          this,
+          Invocation.method(
+            #getMode,
+            [request],
+            {#options: options},
+          ),
+        ),
+      ) as _i4.ResponseFuture<_i33.GetModeResponse>);
+
+  @override
+  _i4.ResponseFuture<_i33.SetModeResponse> setMode(
+    _i33.SetModeRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setMode,
+          [request],
+          {#options: options},
+        ),
+        returnValue: _FakeResponseFuture_2<_i33.SetModeResponse>(
+          this,
+          Invocation.method(
+            #setMode,
+            [request],
+            {#options: options},
+          ),
+        ),
+        returnValueForMissingStub: _FakeResponseFuture_2<_i33.SetModeResponse>(
+          this,
+          Invocation.method(
+            #setMode,
+            [request],
+            {#options: options},
+          ),
+        ),
+      ) as _i4.ResponseFuture<_i33.SetModeResponse>);
+
+  @override
+  _i4.ResponseFuture<_i33.GetLocationResponse> getLocation(
+    _i33.GetLocationRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getLocation,
+          [request],
+          {#options: options},
+        ),
+        returnValue: _FakeResponseFuture_2<_i33.GetLocationResponse>(
+          this,
+          Invocation.method(
+            #getLocation,
+            [request],
+            {#options: options},
+          ),
+        ),
+        returnValueForMissingStub:
+            _FakeResponseFuture_2<_i33.GetLocationResponse>(
+          this,
+          Invocation.method(
+            #getLocation,
+            [request],
+            {#options: options},
+          ),
+        ),
+      ) as _i4.ResponseFuture<_i33.GetLocationResponse>);
+
+  @override
+  _i4.ResponseFuture<_i33.GetWaypointsResponse> getWaypoints(
+    _i33.GetWaypointsRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getWaypoints,
+          [request],
+          {#options: options},
+        ),
+        returnValue: _FakeResponseFuture_2<_i33.GetWaypointsResponse>(
+          this,
+          Invocation.method(
+            #getWaypoints,
+            [request],
+            {#options: options},
+          ),
+        ),
+        returnValueForMissingStub:
+            _FakeResponseFuture_2<_i33.GetWaypointsResponse>(
+          this,
+          Invocation.method(
+            #getWaypoints,
+            [request],
+            {#options: options},
+          ),
+        ),
+      ) as _i4.ResponseFuture<_i33.GetWaypointsResponse>);
+
+  @override
+  _i4.ResponseFuture<_i33.AddWaypointResponse> addWaypoint(
+    _i33.AddWaypointRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #addWaypoint,
+          [request],
+          {#options: options},
+        ),
+        returnValue: _FakeResponseFuture_2<_i33.AddWaypointResponse>(
+          this,
+          Invocation.method(
+            #addWaypoint,
+            [request],
+            {#options: options},
+          ),
+        ),
+        returnValueForMissingStub:
+            _FakeResponseFuture_2<_i33.AddWaypointResponse>(
+          this,
+          Invocation.method(
+            #addWaypoint,
+            [request],
+            {#options: options},
+          ),
+        ),
+      ) as _i4.ResponseFuture<_i33.AddWaypointResponse>);
+
+  @override
+  _i4.ResponseFuture<_i33.RemoveWaypointResponse> removeWaypoint(
+    _i33.RemoveWaypointRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #removeWaypoint,
+          [request],
+          {#options: options},
+        ),
+        returnValue: _FakeResponseFuture_2<_i33.RemoveWaypointResponse>(
+          this,
+          Invocation.method(
+            #removeWaypoint,
+            [request],
+            {#options: options},
+          ),
+        ),
+        returnValueForMissingStub:
+            _FakeResponseFuture_2<_i33.RemoveWaypointResponse>(
+          this,
+          Invocation.method(
+            #removeWaypoint,
+            [request],
+            {#options: options},
+          ),
+        ),
+      ) as _i4.ResponseFuture<_i33.RemoveWaypointResponse>);
+
+  @override
+  _i4.ResponseFuture<_i33.GetObstaclesResponse> getObstacles(
+    _i33.GetObstaclesRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getObstacles,
+          [request],
+          {#options: options},
+        ),
+        returnValue: _FakeResponseFuture_2<_i33.GetObstaclesResponse>(
+          this,
+          Invocation.method(
+            #getObstacles,
+            [request],
+            {#options: options},
+          ),
+        ),
+        returnValueForMissingStub:
+            _FakeResponseFuture_2<_i33.GetObstaclesResponse>(
+          this,
+          Invocation.method(
+            #getObstacles,
+            [request],
+            {#options: options},
+          ),
+        ),
+      ) as _i4.ResponseFuture<_i33.GetObstaclesResponse>);
+
+  @override
+  _i4.ResponseFuture<_i33.GetPathsResponse> getPaths(
+    _i33.GetPathsRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getPaths,
+          [request],
+          {#options: options},
+        ),
+        returnValue: _FakeResponseFuture_2<_i33.GetPathsResponse>(
+          this,
+          Invocation.method(
+            #getPaths,
+            [request],
+            {#options: options},
+          ),
+        ),
+        returnValueForMissingStub: _FakeResponseFuture_2<_i33.GetPathsResponse>(
+          this,
+          Invocation.method(
+            #getPaths,
+            [request],
+            {#options: options},
+          ),
+        ),
+      ) as _i4.ResponseFuture<_i33.GetPathsResponse>);
+
+  @override
+  _i4.ResponseFuture<_i33.GetPropertiesResponse> getProperties(
+    _i33.GetPropertiesRequest? request, {
+    _i3.CallOptions? options,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getProperties,
+          [request],
+          {#options: options},
+        ),
+        returnValue: _FakeResponseFuture_2<_i33.GetPropertiesResponse>(
+          this,
+          Invocation.method(
+            #getProperties,
+            [request],
+            {#options: options},
+          ),
+        ),
+        returnValueForMissingStub:
+            _FakeResponseFuture_2<_i33.GetPropertiesResponse>(
+          this,
+          Invocation.method(
+            #getProperties,
+            [request],
+            {#options: options},
+          ),
+        ),
+      ) as _i4.ResponseFuture<_i33.GetPropertiesResponse>);
 
   @override
   _i4.ResponseFuture<_i20.DoCommandResponse> doCommand(

--- a/test/unit_test/services/navigation_test.dart
+++ b/test/unit_test/services/navigation_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:viam_sdk/protos/common/common.dart' as common_pb;
+import 'package:viam_sdk/protos/service/navigation.dart';
+import 'package:viam_sdk/src/gen/common/v1/common.pb.dart' as common_gen;
+import 'package:viam_sdk/src/gen/service/navigation/v1/navigation.pbgrpc.dart';
+import 'package:viam_sdk/src/utils.dart';
+import 'package:viam_sdk/viam_sdk.dart';
+
+import '../mocks/mock_response_future.dart';
+import '../mocks/service_clients_mocks.mocks.dart';
+
+class FakeNavigationClient extends NavigationClient {
+  @override
+  NavigationServiceClient get client => _client;
+
+  final MockNavigationServiceClient _client;
+
+  FakeNavigationClient(super.name, super.channel, this._client);
+}
+
+void main() {
+  late NavigationClient client;
+  late MockNavigationServiceClient serviceClient;
+
+  setUp(() {
+    serviceClient = MockNavigationServiceClient();
+    client = FakeNavigationClient('navigation', MockClientChannelBase(), serviceClient);
+  });
+
+  group('Navigation RPC Client Tests', () {
+    test('getMode', () async {
+      when(
+        serviceClient.getMode(any, options: anyNamed('options')),
+      ).thenAnswer((_) => MockResponseFuture.value(GetModeResponse(mode: Mode.MODE_WAYPOINT)));
+      final response = await client.getMode();
+      expect(response, equals(Mode.MODE_WAYPOINT));
+    });
+
+    test('setMode', () async {
+      when(
+        serviceClient.setMode(any, options: anyNamed('options')),
+      ).thenAnswer((_) => MockResponseFuture.value(SetModeResponse()));
+      await client.setMode(Mode.MODE_MANUAL);
+      verify(serviceClient.setMode(any, options: anyNamed('options'))).called(1);
+    });
+
+    test('getLocation', () async {
+      final expected = GetLocationResponse(location: common_pb.GeoPoint(latitude: 1, longitude: 2), compassHeading: 90);
+      when(serviceClient.getLocation(any, options: anyNamed('options'))).thenAnswer((_) => MockResponseFuture.value(expected));
+      final response = await client.getLocation();
+      expect(response, equals(expected));
+    });
+
+    test('getWaypoints', () async {
+      final expected = [Waypoint(id: 'wp1', location: common_pb.GeoPoint(latitude: 1, longitude: 2))];
+      when(
+        serviceClient.getWaypoints(any, options: anyNamed('options')),
+      ).thenAnswer((_) => MockResponseFuture.value(GetWaypointsResponse(waypoints: expected)));
+      final response = await client.getWaypoints();
+      expect(response, equals(expected));
+    });
+
+    test('addWaypoint', () async {
+      when(
+        serviceClient.addWaypoint(any, options: anyNamed('options')),
+      ).thenAnswer((_) => MockResponseFuture.value(AddWaypointResponse()));
+      await client.addWaypoint(common_pb.GeoPoint(latitude: 1, longitude: 2));
+      verify(serviceClient.addWaypoint(any, options: anyNamed('options'))).called(1);
+    });
+
+    test('removeWaypoint', () async {
+      when(
+        serviceClient.removeWaypoint(any, options: anyNamed('options')),
+      ).thenAnswer((_) => MockResponseFuture.value(RemoveWaypointResponse()));
+      await client.removeWaypoint('wp1');
+      verify(serviceClient.removeWaypoint(any, options: anyNamed('options'))).called(1);
+    });
+
+    test('doCommand', () async {
+      final expected = {'command': 'test'};
+      when(
+        serviceClient.doCommand(any, options: anyNamed('options')),
+      ).thenAnswer((_) => MockResponseFuture.value(common_gen.DoCommandResponse()..result = expected.toStruct()));
+      final response = await client.doCommand(expected);
+      expect(response, equals(expected));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a `NavigationClient` to the SDK, built on the navigation service protos that are already vendored at `lib/src/gen/service/navigation/v1/`. The client follows the existing `VisionClient` pattern.

## Changes

- **`lib/src/services/navigation.dart`** — new `NavigationClient` with:
  - `getMode` / `setMode`
  - `getLocation`
  - `getWaypoints` / `addWaypoint` / `removeWaypoint`
  - `getObstacles`
  - `getPaths`
  - `getProperties`
  - `doCommand`
  - `getResourceName` / `fromRobot` helpers
  - Exposes a `NavigationProperties` typedef for `GetPropertiesResponse`.
- **`lib/viam_sdk.dart`** — exports `src/services/navigation.dart`.
- **`lib/src/resource/registry.dart`** — registers `NavigationClient.subtype`.
- **`test/unit_test/services/navigation_test.dart`** — unit tests mirroring `vision_test.dart`, covering `getMode`, `setMode`, `getLocation`, `getWaypoints`, `addWaypoint`, `removeWaypoint`, and `doCommand`.
- **`test/unit_test/mocks/service_clients_mocks.dart`** + regenerated `.mocks.dart` — adds `MockSpec<NavigationServiceClient>`.

## Notes

No proto/codegen changes were needed — the navigation protos and the `lib/protos/service/navigation.dart` barrel already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDoBCPZjyzEBMz6M6tk6uL)_